### PR TITLE
Containerize Boltz and add CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+
+# Git
+.git/
+.gitignore
+.dockerignore
+
+# Ignore virtual environments
+venv/
+env/
+.venv/
+
+# Build artifacts
+build/
+dist/
+
+# Config files
+*.env
+
+# IDE system files
+*.swp
+.vscode/
+.idea/
+.DS_STORE
+
+# Logs and temporary files
+logs/
+*.log
+tmp/
+*.tmp
+*.bak
+
+# Exclude essential files
+!Dockerfile
+!LICENSE
+!README.md

--- a/.github/workflows/docker-build-base.yaml
+++ b/.github/workflows/docker-build-base.yaml
@@ -1,0 +1,54 @@
+name: Build and push base docker image
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "scripts/**"
+      - "src/**"
+      - "pyproject.toml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "scripts/**"
+      - "src/**"
+      - "pyproject.toml"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-push-base:
+    if: "!contains(github.event.head_commit.message, '[no-ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Convert repository name to lowercase
+        run: echo "IMAGE_NAME=$(echo ${GITHUB_REPOSITORY} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main
+          build-args: BASE_IMAGE=python:3.10-slim
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-cuda12-1.yaml
+++ b/.github/workflows/docker-build-cuda12-1.yaml
@@ -1,0 +1,54 @@
+name: Build and push CUDA 12.1 docker image
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "scripts/**s"
+      - "src/**"
+      - "pyproject.toml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "scripts/**"
+      - "src/**"
+      - "pyproject.toml"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-push-cuda12-1:
+    if: "!contains(github.event.head_commit.message, '[no-ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Convert repository name to lowercase
+        run: echo "IMAGE_NAME=$(echo ${GITHUB_REPOSITORY} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cuda12-1
+          build-args: BASE_IMAGE=nvidia/cuda:12.1.1-cudnn8-devel-ubuntu22.04
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-cuda12-4.yaml
+++ b/.github/workflows/docker-build-cuda12-4.yaml
@@ -1,0 +1,54 @@
+name: Build and push CUDA 12.4 docker image
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "scripts/**"
+      - "src/**"
+      - "pyproject.toml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "Dockerfile"
+      - "scripts/**"
+      - "src/**"
+      - "pyproject.toml"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-push-cuda12-4:
+    if: "!contains(github.event.head_commit.message, '[no-ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Convert repository name to lowercase
+        run: echo "IMAGE_NAME=$(echo ${GITHUB_REPOSITORY} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cuda12-4
+          build-args: BASE_IMAGE=nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  git \
+  build-essential \
+  python3 \
+  python3-pip \
+  python3-venv \
+  python3-dev \
+  && apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir boltz
+
+FROM ${BASE_IMAGE}
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3 \
+  && apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+ENV LANG=C.UTF-8 \
+  PYTHONUNBUFFERED=1
+
+ARG USERNAME=boltz
+ARG UID=900
+ARG GID=900
+
+RUN groupadd --gid $GID $USERNAME && \
+  useradd --uid $UID --gid $GID --create-home --shell /bin/bash $USERNAME
+
+WORKDIR /app
+
+COPY --chown=${USERNAME}:${USERNAME} LICENSE README.md /app/
+COPY --chown=${USERNAME}:${USERNAME} examples /app/examples
+COPY --chown=${USERNAME}:${USERNAME} scripts /app/scripts
+COPY --chown=${USERNAME}:${USERNAME} docs /app/docs
+
+USER $USERNAME
+
+CMD ["boltz"]


### PR DESCRIPTION
Add Dockerfile, .dockerignore file, and docker build workflows for images with tags "cuda12-1" & "cuda12-4" & "main" (python:3.10-slim base image). CI only runs with changes to "src/" "scripts/" "Dockerfile" or "pyproject.toml". Skip builds with a git commit summary including "[no-ci]". Have a good day.