### PR TITLE
Add screen functionality

### DIFF
--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -6,6 +6,10 @@ Once you have installed `boltz`, you can start making predictions by simply runn
 
 where `<INPUT_PATH>` is a path to the input file or a directory. The input file can either be in fasta (enough for most use cases) or YAML  format (for more complex inputs). If you specify a directory, `boltz` will run predictions on each `.yaml` or `.fasta` file in the directory.
 
+The `screen` function allows you to predict interactions for multiple ligands, accepting a single `.sdf` file, a directory of `.sdf` files, or a `.smi` file with ligand IDs and SMILES strings separated by spaces or tabs. Proteins can be provided as `.pdb` or `.fasta` files (recommended). The `screen` function supports all arguments from `predict` and additionally allows specifying a precomputed MSA file (`.m3a`) with `--msa_path`. If no MSA is available, the `--use_msa_server` flag can generate it automatically. **Note**: Using `--use_msa_server` sends data to an external server, and confidentiality cannot be guaranteed.
+
+`boltz screen --protein <PROTEIN_PATH> --ligands <LIGANDS_PATH>`
+
 Before diving into more details about the input formats, here are the key differences in what they each support:
 
 | Feature  | Fasta              | YAML    |
@@ -131,14 +135,14 @@ The following options are available for the `predict` command:
 After running the model, the generated outputs are organized into the output directory following the structure below:
 ```
 out_dir/
-├── lightning_logs/                                            # Logs generated during training or evaluation
-├── predictions/                                               # Contains the model's predictions
-    ├── [input_file1]/
-        ├── [input_file1]_model_0.cif                          # The predicted structure in CIF format
+��������� lightning_logs/                                            # Logs generated during training or evaluation
+��������� predictions/                                               # Contains the model's predictions
+    ��������� [input_file1]/
+        ��������� [input_file1]_model_0.cif                          # The predicted structure in CIF format
         ...
-        └── [input_file1]_model_[diffusion_samples-1].cif      # The predicted structure in CIF format
-    └── [input_file2]/
+        ��������� [input_file1]_model_[diffusion_samples-1].cif      # The predicted structure in CIF format
+    ��������� [input_file2]/
         ...
-└── processed/                                                 # Processed data used during execution 
+��������� processed/                                                 # Processed data used during execution 
 ```
 The `predictions` folder contains a unique folder for each input file. The input folders contain diffusion_samples predictions saved in the output_format. The `processed` folder contains the processed input files that are used by the model during inference.


### PR DESCRIPTION
This PR introduces a new screen function, enabling the ability to test multiple ligands (e.g., from a compound library) against a single target protein.

Key Features:

- Input Support:
    - Accepts protein input as a .fasta file (recommended) or a .pdb file.
    - Handles ligands from a directory of .sdf files, a single .sdf file, or .smi files containing ligand IDs and SMILES strings.
- Automated MSA Handling:
    - Automatically performs multiple sequence alignment (MSA) if a precomputed .m3a file is not provided, using the --use_msa_server option.
- Query Preparation:
    - Prepares a structured query directory automatically, making the process streamlined.
- Integration with predict:
    - Fully utilizes the existing predict functionality and supports all its regular features.

Example:
- To screen a .fasta file with a directory of .sdf files:
`boltz screen --protein protein.fasta --ligands ligand_directory --use_msa_server`

This functionality is great for workflows involving large-scale ligand screening, as it simplifies things by automating MSA generation (when needed) and organizing input queries for you. I originally put this together for a virtual screening workflow and hope it can be useful to others too.

As for future improvements, it could be interesting to explore adding support for Singularity or SLURM for easier use on HPC systems. That might be better suited for a separate project, but I think this screen functionality fits nicely into the main repo and would be a solid addition.