### PR TITLE
Debug run fixes 

### DIFF
--- a/scripts/train/configs/confidence.yaml
+++ b/scripts/train/configs/confidence.yaml
@@ -75,7 +75,7 @@ data:
   atoms_per_window_queries: 32
 
 model:
-  _target_: boltz.model.models.boltz.BoltzPreview
+  _target_: boltz.model.model.Boltz1
   atom_s: 128
   atom_z: 16
   token_s: 384
@@ -125,12 +125,10 @@ model:
     offload_to_cpu: false
 
   structure_prediction_training: false
-  run_trunk_and_structure: true
   confidence_prediction: true
   alpha_pae: 1
   confidence_imitate_trunk: true
   confidence_model_args:
-    use_gaussian: false
     num_dist_bins: 64
     max_dist: 22
     add_s_to_z_prod: true
@@ -142,7 +140,6 @@ model:
       num_plddt_bins: 50
       num_pde_bins: 64
       num_pae_bins: 64
-      relative_confidence: none
 
   training_args:
     recycling_steps: 3
@@ -169,6 +166,7 @@ model:
     sampling_steps: 200
     diffusion_samples: 5
     symmetry_correction: true
+    run_confidence_sequentially: false
 
   diffusion_process_args:
     sigma_min: 0.0004

--- a/scripts/train/configs/structure.yaml
+++ b/scripts/train/configs/structure.yaml
@@ -123,7 +123,6 @@ model:
 
   confidence_prediction: false
   confidence_model_args:
-    use_gaussian: false
     num_dist_bins: 64
     max_dist: 22
     add_s_to_z_prod: true
@@ -135,7 +134,6 @@ model:
       num_plddt_bins: 50
       num_pde_bins: 64
       num_pae_bins: 64
-      relative_confidence: none
 
   training_args:
     recycling_steps: 3
@@ -161,6 +159,7 @@ model:
     sampling_steps: 200
     diffusion_samples: 5
     symmetry_correction: true
+    run_confidence_sequentially: false
 
   diffusion_process_args:
     sigma_min: 0.0004

--- a/src/boltz/model/model.py
+++ b/src/boltz/model/model.py
@@ -123,9 +123,6 @@ class Boltz1(LightningModule):
             "resolved_loss",
             "pde_loss",
             "pae_loss",
-            "rel_plddt_loss",
-            "rel_pde_loss",
-            "rel_pae_loss",
         ]:
             self.train_confidence_loss_dict_logger[m] = MeanMetric()
 


### PR DESCRIPTION
Resolves a few minor issues for the structure and confidence module debug training runs. 

For the structure module training,
1. `run_confidence_sequentially` is not provided in the `validation_args` of the config. Just added the default `False` value in the config.

For the confidence module training,
1. Replaced the model class with `boltz.model.model.Boltz1` instead of `boltz.model.models.boltz.BoltzPreview`
2. `run_confidence_sequentially` set as False in the validation args similar to the structure config changes.
3. The following arguments are invalid, therefore removed them, `run_trunk_and_structure` in `model` args, `use_gaussian` in `confidence_model_args` and `relative_confidence` in `confidence_args`. The last two were also present in the structure config, therefore removed them for correctness. 
4.  `["rel_plddt_loss", "rel_pde_loss", "rel_pae_loss"]` are not logged/present in the loss breakdown of `confidence_loss_dict`. Removed them. 

Post these changes, the debug runs seem to run correctly. Let me know if something needs to be changed here.