### PR TITLE
Small fixes to process cif files and use them in training

### DIFF
--- a/scripts/process/mmcif.py
+++ b/scripts/process/mmcif.py
@@ -966,6 +966,7 @@ def parse_mmcif(  # noqa: C901, PLR0915, PLR0912
                         entity=entity.name,
                         residues=residues,
                         type=const.chain_type_ids["NONPOLYMER"],
+                        sequence=None
                     )
                 )
 
@@ -1119,4 +1120,4 @@ def parse_mmcif(  # noqa: C901, PLR0915, PLR0912
         mask=mask,
     )
 
-    return ParsedStructure(data=data, info=info)
+    return ParsedStructure(data=data, info=info, covalents=[])

--- a/scripts/process/rcsb.py
+++ b/scripts/process/rcsb.py
@@ -92,15 +92,18 @@ def finalize(outdir: Path) -> None:
     failed_count = 0
     records = []
     for record in records_dir.iterdir():
-        path = records_dir / record
+        path = record
         try:
             with path.open("r") as f:
                 records.append(json.load(f))
         except:  # noqa: E722
             failed_count += 1
             print(f"Failed to parse {record}")  # noqa: T201
-    print(f"Failed to parse {failed_count} entries)")  # noqa: T201
-
+    if failed_count > 0:
+        print(f"Failed to parse {failed_count} entries.")  # noqa: T201
+    else:
+        print("All entries parsed successfully.")  
+    
     # Save manifest
     outpath = outdir / "manifest.json"
     with outpath.open("w") as f:

--- a/src/boltz/data/module/training.py
+++ b/src/boltz/data/module/training.py
@@ -115,7 +115,7 @@ def load_input(record: Record, target_dir: Path, msa_dir: Path) -> Input:
     for chain in record.chains:
         msa_id = chain.msa_id
         # Load the MSA for this chain, if any
-        if msa_id != -1:
+        if msa_id != -1 and msa_id != "":
             msa = np.load(msa_dir / f"{msa_id}.npz")
             msas[chain.chain_id] = MSA(**msa)
 


### PR DESCRIPTION
Fixing to reproduce processing:
 
- a few differences in class usage
- paths repetition in parse verification lead to "failed" messages  (at least in my case)  

Using a single PDB entry as a test, I converted it to the npz format and compared with the one in the provided training set.  
- I found that "coords" and "ensemble" fields in the provided npz file are missing when processing from the mmcif file, although they do not appear to be used during  training. 
- The "conformer" field in "atoms" seems different as well, I don't know if that is expected.
- Additionally, the msa_id values  are missing.  I  added the option to ignore empty MSA  (msa_id=="") during training as temporary fix.


Happy new year!