### PR TITLE
Fix get_resolution in data preprocessing

### DIFF
--- a/scripts/process/mmcif.py
+++ b/scripts/process/mmcif.py
@@ -151,7 +151,7 @@ def get_resolution(block: gemmi.cif.Block) -> float:
         "_reflns.d_resolution_high",
     ):
         with contextlib.suppress(Exception):
-            resolution = float(block.find([res_key])[0])
+            resolution = float(block.find([res_key])[0].str(0))
             break
     return resolution
 


### PR DESCRIPTION
`get_resolution` was always returning `0.0`, due to incorrectly unwrapping the `gemmi` row:
```
ipdb> block.find([res_key])[0]
<gemmi.cif.Table.Row: 2.800>
ipdb> float(block.find([res_key])[0])
*** TypeError: float() argument must be a string or a real number, not 'gemmi.cif.Row'
ipdb> float(block.find([res_key])[0].str(0))
2.8
```