### PR TITLE
add name to wandb logger

### DIFF
--- a/scripts/train/train.py
+++ b/scripts/train/train.py
@@ -178,6 +178,7 @@ def train(raw_config: str, args: list[str]) -> None:  # noqa: C901, PLR0912, PLR
     loggers = []
     if wandb:
         wdb_logger = WandbLogger(
+            name=wandb["name"],
             group=wandb["name"],
             save_dir=cfg.output,
             project=wandb["project"],


### PR DESCRIPTION
This will use the specified name in wandb logging rather than a random one.

See the last run showing the specified name using this yaml config:
```
wandb:
   name: structure_central_256
   project: boltz
   entity: ***
```

![image](https://github.com/user-attachments/assets/02b64e6f-586c-49a3-a3f4-8a0b402ff3b8)
