### PR TITLE
mmcif: scale qa_metric.PLDDT to [0,100]

### DIFF
--- a/src/boltz/data/write/mmcif.py
+++ b/src/boltz/data/write/mmcif.py
@@ -180,7 +180,7 @@ def to_mmcif(structure: Structure, plddts: Optional[Tensor] = None) -> str:  # n
                     self.qa_metrics.append(
                         _LocalPLDDT(
                             asym_unit_map[chain_idx].residue(residue_idx),
-                            plddts[res_num].item(),
+                            round(plddts[res_num].item() * 100, 2),
                         )
                     )
                     res_num += 1


### PR DESCRIPTION
This follows what was already done for B-factors in https://github.com/jwohlwend/boltz/commit/d0d57ba380682e0e36245e5702c86f13f77a7db8

It seems to be the convention to have those values in [0,100] rather than [0,1].
E.g, this is useful when visualizing the structure with `mol*`, as it would automatically apply an appropriate pLDDT colorscheme:

Before:
![before](https://github.com/user-attachments/assets/bff7dd4f-8361-40d7-8213-c67bb33ec483)

After:
![after](https://github.com/user-attachments/assets/8da13e1e-8a86-436d-98a3-a5b2d24d6c98)
