### PR TITLE
Update PDB writer to retain ligand bond order

### DIFF
--- a/src/boltz/data/write/pdb.py
+++ b/src/boltz/data/write/pdb.py
@@ -110,7 +110,7 @@ def to_pdb(structure: Structure, plddts: Optional[Tensor] = None) -> str:  # noq
                 continue
             atom1_idx = atom_reindex_ter[bond["atom_1"]]
             atom2_idx = atom_reindex_ter[bond["atom_2"]]
-            conect_line = f"CONECT{atom1_idx:>5}{atom2_idx:>5}"
+            conect_line = f"CONECT{atom1_idx:>5}" + f"{atom2_idx:>5}"*max(bond["type"]%4,1)
             pdb_lines.append(conect_line)
 
     pdb_lines.append("END")


### PR DESCRIPTION
By using the bond type information, the bond order of the ligand can be retained for the PDB writer by changing the CONECT writer section:
CONECT 1 2    becomes
CONECT 1 2 2
for double bonds etc.

Fixes https://github.com/jwohlwend/boltz/issues/195
Thanking @ijpulidos for the help