### PR TITLE
Update model.py to detach diff_token_repr

### DIFF
--- a/src/boltz/model/model.py
+++ b/src/boltz/model/model.py
@@ -349,7 +349,7 @@ class Boltz1(LightningModule):
                     s=s.detach(),
                     z=z.detach(),
                     s_diffusion=(
-                        dict_out["diff_token_repr"]
+                        dict_out["diff_token_repr"].detach()
                         if self.confidence_module.use_s_diffusion
                         else None
                     ),


### PR DESCRIPTION
I believe `diff_token_repr` is supposed to be detached. I don't think this impacts the way training was set up (serially between trunk and confidence), as relevant parameter gradients are disabled, nor would it impact inference. However, I believe concurrent training would cause an issue as we would backprop from the confidence head to the diffusion module and trunk.