### PR TITLE
Feat/cyclic offset

### DIFF
--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -40,6 +40,7 @@ sequences:
         id: [CHAIN_ID, CHAIN_ID]    # multiple ids in case of multiple identical entities
         ...
 constraints:
+    - cyclic: CHAIN_ID
     - bond:
         atom1: [CHAIN_ID, RES_IDX, ATOM_NAME]
         atom2: [CHAIN_ID, RES_IDX, ATOM_NAME]
@@ -52,6 +53,7 @@ constraints:
 The `modifications` field is an optional field that allows you to specify modified residues in the polymer (`protein`, `dna` or`rna`). The `position` field specifies the index (starting from 1) of the residue, and `ccd` is the CCD code of the modified residue. This field is currently only supported for CCD ligands.
 
 `constraints` is an optional field that allows you to specify additional information about the input structure. 
+* The `cyclic` constraint specifies the chain on which a cyclic offset is applied. A cyclic offset modifies the traditional relative positional encoding from depicting distances left-to-right to depicting a cyclized entity in a head-to-tail fashion. `CHAIN_ID` refers to the id of the residue set above.
 
 * The `bond` constraint specifies covalent bonds between two atoms (`atom1` and `atom2`). It is currently only supported for CCD ligands and canonical residues, `CHAIN_ID` refers to the id of the residue set above, `RES_IDX` is the index (starting from 1) of the residue (1 for ligands), and `ATOM_NAME` is the standardized atom name (can be verified in CIF file of that component on the RCSB website).
 

--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -35,12 +35,12 @@ sequences:
         modifications:
           - position: RES_IDX   # index of residue, starting from 1
             ccd: CCD            # CCD code of the modified residue
-        
+        cyclic: false
+     
     - ENTITY_TYPE:
         id: [CHAIN_ID, CHAIN_ID]    # multiple ids in case of multiple identical entities
         ...
 constraints:
-    - cyclic: CHAIN_ID
     - bond:
         atom1: [CHAIN_ID, RES_IDX, ATOM_NAME]
         atom2: [CHAIN_ID, RES_IDX, ATOM_NAME]
@@ -50,7 +50,7 @@ constraints:
 ```
 `sequences` has one entry for every unique chain/molecule in the input. Each polymer entity as a `ENTITY_TYPE`  either `protein`, `dna` or `rna` and have a `sequence` attribute. Non-polymer entities are indicated by `ENTITY_TYPE` equal to `ligand` and have a `smiles` or `ccd` attribute. `CHAIN_ID` is the unique identifier for each chain/molecule, and it should be set as a list in case of multiple identical entities in the structure. For proteins, the `msa` key is required by default but can be omited by passing the `--use_msa_server` flag which will auto-generate the MSA using the mmseqs2 server. If you wish to use a precomputed MSA, use the `msa` attribute with `MSA_PATH` indicating the path to the `.a3m` file containing the MSA for that protein. If you wish to explicitly run single sequence mode (which is generally advised against as it will hurt model performance), you may do so by using the special keyword `empty` for that protein (ex: `msa: empty`). For custom MSA, you may wish to indicate pairing keys to the model. You can do so by using a CSV format instead of a3m with two columns: `sequence` with the protein sequences and `key` which is a unique identifier indicating matching rows across CSV files of each protein chain.
 
-The `modifications` field is an optional field that allows you to specify modified residues in the polymer (`protein`, `dna` or`rna`). The `position` field specifies the index (starting from 1) of the residue, and `ccd` is the CCD code of the modified residue. This field is currently only supported for CCD ligands.
+The `modifications` field is an optional field that allows you to specify modified residues in the polymer (`protein`, `dna` or`rna`). The `position` field specifies the index (starting from 1) of the residue, and `ccd` is the CCD code of the modified residue. This field is currently only supported for CCD ligands. The `cyclic` flag should be used to specify polymer chains (not ligands) that are cyclic. 
 
 `constraints` is an optional field that allows you to specify additional information about the input structure. 
 
@@ -59,7 +59,6 @@ The `modifications` field is an optional field that allows you to specify modifi
 
 * The `pocket` constraint specifies the residues associated with a ligand, where `binder` refers to the chain binding to the pocket (which can be a molecule, protein, DNA or RNA) and `contacts` is the list of chain and residue indices (starting from 1) associated with the pocket. The model currently only supports the specification of a single `binder` chain (and any number of `contacts` residues in other chains).
 
-* The `cyclic` constraint specifies the chain on which a cyclic offset is applied. A cyclic offset modifies the traditional relative positional encoding from depicting distances left-to-right to depicting a cyclized entity in a head-to-tail fashion. `CHAIN_ID` refers to the id of the residue set above.
 As an example:
 
 ```yaml

--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -53,12 +53,13 @@ constraints:
 The `modifications` field is an optional field that allows you to specify modified residues in the polymer (`protein`, `dna` or`rna`). The `position` field specifies the index (starting from 1) of the residue, and `ccd` is the CCD code of the modified residue. This field is currently only supported for CCD ligands.
 
 `constraints` is an optional field that allows you to specify additional information about the input structure. 
-* The `cyclic` constraint specifies the chain on which a cyclic offset is applied. A cyclic offset modifies the traditional relative positional encoding from depicting distances left-to-right to depicting a cyclized entity in a head-to-tail fashion. `CHAIN_ID` refers to the id of the residue set above.
+
 
 * The `bond` constraint specifies covalent bonds between two atoms (`atom1` and `atom2`). It is currently only supported for CCD ligands and canonical residues, `CHAIN_ID` refers to the id of the residue set above, `RES_IDX` is the index (starting from 1) of the residue (1 for ligands), and `ATOM_NAME` is the standardized atom name (can be verified in CIF file of that component on the RCSB website).
 
 * The `pocket` constraint specifies the residues associated with a ligand, where `binder` refers to the chain binding to the pocket (which can be a molecule, protein, DNA or RNA) and `contacts` is the list of chain and residue indices (starting from 1) associated with the pocket. The model currently only supports the specification of a single `binder` chain (and any number of `contacts` residues in other chains).
 
+* The `cyclic` constraint specifies the chain on which a cyclic offset is applied. A cyclic offset modifies the traditional relative positional encoding from depicting distances left-to-right to depicting a cyclized entity in a head-to-tail fashion. `CHAIN_ID` refers to the id of the residue set above.
 As an example:
 
 ```yaml

--- a/examples/cyclic_prot.yaml
+++ b/examples/cyclic_prot.yaml
@@ -1,0 +1,7 @@
+version: 1  # Optional, defaults to 1
+sequences:
+  - protein:
+      id: A
+      sequence: QLEDSEVEAVAKG
+      cyclic: true
+

--- a/src/boltz/data/feature/featurizer.py
+++ b/src/boltz/data/feature/featurizer.py
@@ -407,19 +407,20 @@ def process_token_features(
 
     # Token core features
     token_index = torch.arange(len(token_data), dtype=torch.long)
-    residue_index = from_numpy(token_data["res_idx"]).long()
-    asym_id = from_numpy(token_data["asym_id"]).long()
-    entity_id = from_numpy(token_data["entity_id"]).long()
-    sym_id = from_numpy(token_data["sym_id"]).long()
-    mol_type = from_numpy(token_data["mol_type"]).long()
-    res_type = from_numpy(token_data["res_type"]).long()
+    residue_index = from_numpy(np.array(token_data["res_idx"])).long()
+    asym_id = from_numpy(np.array(token_data["asym_id"])).long()
+    entity_id = from_numpy(np.array(token_data["entity_id"])).long()
+    sym_id = from_numpy(np.array(token_data["sym_id"])).long()
+    mol_type = from_numpy(np.array(token_data["mol_type"])).long()
+    res_type = from_numpy(np.array(token_data["res_type"])).long()
     res_type = one_hot(res_type, num_classes=const.num_tokens)
-    disto_center = from_numpy(token_data["disto_coords"])
+    disto_center = from_numpy(np.array(token_data["disto_coords"]))
 
     # Token mask features
     pad_mask = torch.ones(len(token_data), dtype=torch.float)
-    resolved_mask = from_numpy(token_data["resolved_mask"]).float()
-    disto_mask = from_numpy(token_data["disto_mask"]).float()
+    resolved_mask = from_numpy(np.array(token_data["resolved_mask"])).float()
+    disto_mask = from_numpy(np.array(token_data["disto_mask"])).float()
+    cyclic_mask = from_numpy(np.array(token_data["is_cyclic"])).float()
 
     # Token bond features
     if max_tokens is not None:

--- a/src/boltz/data/feature/featurizer.py
+++ b/src/boltz/data/feature/featurizer.py
@@ -420,7 +420,7 @@ def process_token_features(
     pad_mask = torch.ones(len(token_data), dtype=torch.float)
     resolved_mask = from_numpy(token_data["resolved_mask"].copy()).float()
     disto_mask = from_numpy(token_data["disto_mask"].copy()).float()
-    cyclic_mask = from_numpy(token_data["is_cyclic"].copy()).float()
+    cyclic_period = from_numpy(token_data["cyclic_period"].copy())
 
     # Token bond features
     if max_tokens is not None:
@@ -556,7 +556,7 @@ def process_token_features(
         "token_resolved_mask": resolved_mask,
         "token_disto_mask": disto_mask,
         "pocket_feature": pocket_feature,
-        "cyclic_mask": cyclic_mask,
+        "cyclic_period": cyclic_period,
     }
     return token_features
 

--- a/src/boltz/data/feature/featurizer.py
+++ b/src/boltz/data/feature/featurizer.py
@@ -556,6 +556,7 @@ def process_token_features(
         "token_resolved_mask": resolved_mask,
         "token_disto_mask": disto_mask,
         "pocket_feature": pocket_feature,
+        "cyclic_mask": cyclic_mask,
     }
     return token_features
 

--- a/src/boltz/data/feature/featurizer.py
+++ b/src/boltz/data/feature/featurizer.py
@@ -407,20 +407,20 @@ def process_token_features(
 
     # Token core features
     token_index = torch.arange(len(token_data), dtype=torch.long)
-    residue_index = from_numpy(np.array(token_data["res_idx"])).long()
-    asym_id = from_numpy(np.array(token_data["asym_id"])).long()
-    entity_id = from_numpy(np.array(token_data["entity_id"])).long()
-    sym_id = from_numpy(np.array(token_data["sym_id"])).long()
-    mol_type = from_numpy(np.array(token_data["mol_type"])).long()
-    res_type = from_numpy(np.array(token_data["res_type"])).long()
+    residue_index = from_numpy(token_data["res_idx"].copy()).long()
+    asym_id = from_numpy(token_data["asym_id"].copy()).long()
+    entity_id = from_numpy(token_data["entity_id"].copy()).long()
+    sym_id = from_numpy(token_data["sym_id"].copy()).long()
+    mol_type = from_numpy(token_data["mol_type"].copy()).long()
+    res_type = from_numpy(token_data["res_type"].copy()).long()
     res_type = one_hot(res_type, num_classes=const.num_tokens)
-    disto_center = from_numpy(np.array(token_data["disto_coords"]))
+    disto_center = from_numpy(token_data["disto_coords"].copy())
 
     # Token mask features
     pad_mask = torch.ones(len(token_data), dtype=torch.float)
-    resolved_mask = from_numpy(np.array(token_data["resolved_mask"])).float()
-    disto_mask = from_numpy(np.array(token_data["disto_mask"])).float()
-    cyclic_mask = from_numpy(np.array(token_data["is_cyclic"])).float()
+    resolved_mask = from_numpy(token_data["resolved_mask"].copy()).float()
+    disto_mask = from_numpy(token_data["disto_mask"].copy()).float()
+    cyclic_mask = from_numpy(token_data["is_cyclic"].copy()).float()
 
     # Token bond features
     if max_tokens is not None:

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -74,6 +74,7 @@ class ParsedChain:
     entity: str
     type: str
     residues: list[ParsedResidue]
+    is_cyclic: bool
 
 
 ####################################################################################################

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -797,14 +797,15 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
                 msg = f"Invalid cyclic chain: {constraint['cyclic']}. Available chains: {list(chains.keys())}"
                 raise ValueError(msg)
             
-            if constraint["cyclic"] not in list(chains.keys()):
-                msg = f"Invalid cyclic chain: {constraint['cyclic']}. Available chains: {list(chains.keys())}"
-                raise ValueError(msg)
-            cyclic_chain = constraint["cyclic"]
+            for sequence_item in sequence_items:
+                for sequence_type, sequence_data in sequence_item.items():
+                    if sequence_type!="protein" and cyclic_chain_id in sequence_data["id"] :
+                        msg = f"Cyclic constraints are supported only on proteins. Got {sequence_item}"
+                        raise ValueError(msg)
 
             # flip the final flag (cyclic) for chain flagged as cyclic
             for chain_dat_idx, chain_dat in enumerate(chain_data):
-                if chain_dat[0] == cyclic_chain:
+                if chain_dat[0] == cyclic_chain_id:
                     new_chain_dat = []
                     for i, dat in enumerate(chain_dat):
                         if i == len(chain_dat) - 1:

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -453,6 +453,7 @@ def parse_polymer(
         entity=entity,
         residues=parsed,
         type=chain_type,
+        is_cyclic=False,
     )
 
 

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -644,6 +644,7 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
                 entity=entity_id,
                 residues=residues,
                 type=const.chain_type_ids["NONPOLYMER"],
+                is_cyclic=False,
             )
         elif (entity_type == "ligand") and ("smiles" in items[0][entity_type]):
             seq = items[0][entity_type]["smiles"]
@@ -670,6 +671,7 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
                 entity=entity_id,
                 residues=[residue],
                 type=const.chain_type_ids["NONPOLYMER"],
+                is_cyclic=False,
             )
         else:
             msg = f"Invalid entity type: {entity_type}"
@@ -789,6 +791,7 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
     constraints = schema.get("constraints", [])
     for constraint in constraints:
         if "cyclic" in constraint:
+            # TODO: Check that sequence item == protein
             if constraint["cyclic"] not in list(chains.keys()):
                 msg = f"Invalid cyclic chain: {constraint['cyclic']}. Available chains: {list(chains.keys())}"
                 raise ValueError(msg)

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -791,13 +791,12 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
     constraints = schema.get("constraints", [])
     for constraint in constraints:
         if "cyclic" in constraint:
-            sequence_items = schema.get("sequences", [])
-            if constraint["cyclic"] in list(chains.keys()):
-                for sequent_item in sequence_items:
-                    if "protein" not in sequent_item:
-                        msg = f"Cyclic constraints are supported only on proteins. Got {sequent_item}"
-                        raise ValueError(msg)
-
+            sequence_items = schema.get("sequences", {}) # pretty sure this should be a dict but need to check yaml parsing
+            cyclic_chain_id = constraint["cyclic"]
+            if cyclic_chain_id not in list(chains.keys()):
+                msg = f"Invalid cyclic chain: {constraint['cyclic']}. Available chains: {list(chains.keys())}"
+                raise ValueError(msg)
+            
             if constraint["cyclic"] not in list(chains.keys()):
                 msg = f"Invalid cyclic chain: {constraint['cyclic']}. Available chains: {list(chains.keys())}"
                 raise ValueError(msg)

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -791,7 +791,6 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
     constraints = schema.get("constraints", [])
     for constraint in constraints:
         if "cyclic" in constraint:
-            # TODO: Check that sequence item == protein
             sequence_items = schema.get("sequences", [])
             for sequent_item in sequence_items:
                 if "protein" not in sequent_item:

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -792,6 +792,12 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
     for constraint in constraints:
         if "cyclic" in constraint:
             # TODO: Check that sequence item == protein
+            sequence_items = schema.get("sequences", [])
+            for sequent_item in sequence_items:
+                if "protein" not in sequent_item:
+                    msg = f"Cyclic constraints are supported only on proteins. Got {sequent_item}"
+                    raise ValueError(msg)
+
             if constraint["cyclic"] not in list(chains.keys()):
                 msg = f"Invalid cyclic chain: {constraint['cyclic']}. Available chains: {list(chains.keys())}"
                 raise ValueError(msg)

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -792,10 +792,11 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
     for constraint in constraints:
         if "cyclic" in constraint:
             sequence_items = schema.get("sequences", [])
-            for sequent_item in sequence_items:
-                if "protein" not in sequent_item:
-                    msg = f"Cyclic constraints are supported only on proteins. Got {sequent_item}"
-                    raise ValueError(msg)
+            if constraint["cyclic"] in list(chains.keys()):
+                for sequent_item in sequence_items:
+                    if "protein" not in sequent_item:
+                        msg = f"Cyclic constraints are supported only on proteins. Got {sequent_item}"
+                        raise ValueError(msg)
 
             if constraint["cyclic"] not in list(chains.keys()):
                 msg = f"Invalid cyclic chain: {constraint['cyclic']}. Available chains: {list(chains.keys())}"

--- a/src/boltz/data/tokenize/boltz.py
+++ b/src/boltz/data/tokenize/boltz.py
@@ -26,7 +26,7 @@ class TokenData:
     disto_coords: np.ndarray
     resolved_mask: bool
     disto_mask: bool
-    is_cyclic: bool
+    cyclic_period: int
 
 
 class BoltzTokenizer(Tokenizer):
@@ -100,7 +100,7 @@ class BoltzTokenizer(Tokenizer):
                         disto_coords=d_coords,
                         resolved_mask=is_present,
                         disto_mask=is_disto_present,
-                        is_cyclic=chain["is_cyclic"],
+                        cyclic_period=chain["cyclic_period"],
                     )
                     token_data.append(astuple(token))
 
@@ -143,7 +143,7 @@ class BoltzTokenizer(Tokenizer):
                             disto_coords=atom_coords[i],
                             resolved_mask=is_present,
                             disto_mask=is_present,
-                            is_cyclic=chain["is_cyclic"], # Enforced to be False in chain parser
+                            cyclic_period=chain["cyclic_period"], # Enforced to be False in chain parser
                         )
                         token_data.append(astuple(token))
 

--- a/src/boltz/data/tokenize/boltz.py
+++ b/src/boltz/data/tokenize/boltz.py
@@ -143,7 +143,7 @@ class BoltzTokenizer(Tokenizer):
                             disto_coords=atom_coords[i],
                             resolved_mask=is_present,
                             disto_mask=is_present,
-                            is_cyclic=chain["is_cyclic"],
+                            is_cyclic=chain["is_cyclic"], # Enforced to be False in chain parser
                         )
                         token_data.append(astuple(token))
 

--- a/src/boltz/data/tokenize/boltz.py
+++ b/src/boltz/data/tokenize/boltz.py
@@ -26,6 +26,7 @@ class TokenData:
     disto_coords: np.ndarray
     resolved_mask: bool
     disto_mask: bool
+    is_cyclic: bool
 
 
 class BoltzTokenizer(Tokenizer):
@@ -99,6 +100,7 @@ class BoltzTokenizer(Tokenizer):
                         disto_coords=d_coords,
                         resolved_mask=is_present,
                         disto_mask=is_disto_present,
+                        is_cyclic=chain["is_cyclic"],
                     )
                     token_data.append(astuple(token))
 
@@ -141,6 +143,7 @@ class BoltzTokenizer(Tokenizer):
                             disto_coords=atom_coords[i],
                             resolved_mask=is_present,
                             disto_mask=is_present,
+                            is_cyclic=chain["is_cyclic"],
                         )
                         token_data.append(astuple(token))
 

--- a/src/boltz/data/types.py
+++ b/src/boltz/data/types.py
@@ -119,7 +119,7 @@ Chain = [
     ("atom_num", np.dtype("i4")),
     ("res_idx", np.dtype("i4")),
     ("res_num", np.dtype("i4")),
-    ("is_cyclic", np.dtype("?")),
+    ("cyclic_period", np.dtype("i4")),
 ]
 
 Connection = [
@@ -470,7 +470,7 @@ Token = [
     ("disto_coords", np.dtype("3f4")),
     ("resolved_mask", np.dtype("?")),
     ("disto_mask", np.dtype("?")),
-    ("is_cyclic", np.dtype("?")),
+    ("cyclic_period", np.dtype("i4")),
 ]
 
 TokenBond = [

--- a/src/boltz/data/types.py
+++ b/src/boltz/data/types.py
@@ -119,6 +119,7 @@ Chain = [
     ("atom_num", np.dtype("i4")),
     ("res_idx", np.dtype("i4")),
     ("res_num", np.dtype("i4")),
+    ("is_cyclic", np.dtype("?")),
 ]
 
 Connection = [
@@ -469,6 +470,7 @@ Token = [
     ("disto_coords", np.dtype("3f4")),
     ("resolved_mask", np.dtype("?")),
     ("disto_mask", np.dtype("?")),
+    ("is_cyclic", np.dtype("?")),
 ]
 
 TokenBond = [


### PR DESCRIPTION
# Description

The purpose of the PR is to implement the cyclic offset positional encoding in Boltz1. Currently, the residue relative positions are computed linearly, meaning that the sequence is assumed to be a linear peptide. However, this relative positioning does not work well in cyclic peptides. As such, this PR applies the cyclical relative position encoding to allow for better prediction of cyclic species as first reported in the [AfCycDesign preprint](https://www.biorxiv.org/content/10.1101/2023.02.25.529956v1.full).

We are showing the result of applying the cyclic offset on the cyclic peptides tested by the AfCycDesign authors (see figure below). We are comparing the RSMD achieved using the standard linear offset with the RSMD achieved using the cyclic offset. The figure shows that for the majority of the peptides the cyclic offset achieved better alignment with the ground truth compared to the linear offset.

![image](https://github.com/user-attachments/assets/5f0fe312-cc36-41d6-8f57-30210fe69651)