### PR TITLE
fix: correctly handle chirality information

### DIFF
--- a/scripts/process/mmcif.py
+++ b/scripts/process/mmcif.py
@@ -428,7 +428,7 @@ def parse_ccd_residue(  # noqa: PLR0915, C901
             )
         ref_atom = ref_mol.GetAtoms()[0]
         chirality_type = const.chirality_type_ids.get(
-            ref_atom.GetChiralTag(), unk_chirality
+            str(ref_atom.GetChiralTag()), unk_chirality
         )
         atom = ParsedAtom(
             name=ref_atom.GetProp("name"),
@@ -479,7 +479,7 @@ def parse_ccd_residue(  # noqa: PLR0915, C901
         ref_coords = conformer.GetAtomPosition(atom.GetIdx())
         ref_coords = (ref_coords.x, ref_coords.y, ref_coords.z)
         chirality_type = const.chirality_type_ids.get(
-            atom.GetChiralTag(), unk_chirality
+            str(atom.GetChiralTag()), unk_chirality
         )
 
         # If the atom is a leaving atom, skip if not in the PDB and is_covalent
@@ -685,7 +685,7 @@ def parse_polymer(  # noqa: C901, PLR0915, PLR0912
                     conformer=ref_coords,
                     is_present=atom_is_present,
                     chirality=const.chirality_type_ids.get(
-                        ref_atom.GetChiralTag(), unk_chirality
+                        str(ref_atom.GetChiralTag()), unk_chirality
                     ),
                 )
             )

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -237,7 +237,7 @@ def parse_ccd_residue(
         pos = (0, 0, 0)
         ref_atom = ref_mol.GetAtoms()[0]
         chirality_type = const.chirality_type_ids.get(
-            ref_atom.GetChiralTag(), unk_chirality
+            str(ref_atom.GetChiralTag()), unk_chirality
         )
         atom = ParsedAtom(
             name=ref_atom.GetProp("name"),
@@ -279,7 +279,7 @@ def parse_ccd_residue(
         ref_coords = conformer.GetAtomPosition(atom.GetIdx())
         ref_coords = (ref_coords.x, ref_coords.y, ref_coords.z)
         chirality_type = const.chirality_type_ids.get(
-            atom.GetChiralTag(), unk_chirality
+            str(atom.GetChiralTag()), unk_chirality
         )
 
         # Get PDB coordinates, if any
@@ -425,7 +425,7 @@ def parse_polymer(
                     conformer=ref_coords,
                     is_present=atom_is_present,
                     chirality=const.chirality_type_ids.get(
-                        ref_atom.GetChiralTag(), unk_chirality
+                        str(ref_atom.GetChiralTag()), unk_chirality
                     ),
                 )
             )


### PR DESCRIPTION
This PR fixes a bug in the handling of chirality information. Previously, all chirality tags were incorrectly assigned as "unknown chirality" regardless of the input, leading to incorrect results when processing small molecule data.