### PR TITLE
fix: Minimum Python version update + results folder .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Boltz prediction outputs
+#   All result files generated from a boltz prediction call
+boltz_results_*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "boltz"
 version = "0.4.1"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 description = "Boltz-1"
 readme = "README.md"
 dependencies = [


### PR DESCRIPTION
Tiny fix/tidy commit

### Problem

I went to build this on Python 3.12, which failed due to some breaking change introduced in it compared to the dependency versions within pyproject.toml. Downgraded to 3.9 in accordance with the pyproject.toml requirement. Failed due to "numba==0.61.0" only being available on Python 3.10 and later: https://pypi.org/project/numba/0.61.0/

Slight tweak, while validating changes to the repo on the provided examples, the result outputs clutter the diff. Given they all follow the "boltz_results_..." format, might want to add that into the .gitignore.

### Solution

Downgrading the dependencies is usually more risky than just bumping the minimum Python version if they all are compatible with the newer Python version.

Added a new section for boltz outputs to the .gitignore "boltz_results_*/". Given this is just a tiny quality of life change, I can see an argument for/against it.