### PR TITLE
Add command-line chunking parameters for flexible VRAM utilization

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -513,6 +513,30 @@ def cli() -> None:
     help="Whether to dump the pde into a npz file. Default is False.",
 )
 @click.option(
+    "--chunk_size_transition_z",
+    type=int,
+    help="Transition Z chunk size. Default is 64.",
+    default=64,
+)
+@click.option(
+    "--chunk_size_transition_msa",
+    type=int,
+    help="Transition MSA chunk size. Default is 32.",
+    default=32,
+)
+@click.option(
+    "--chunk_size_outer_product",
+    type=int,
+    help="Outer product chunk size. Default is 4.",
+    default=4,
+)
+@click.option(
+    "--chunk_size_tri_attn",
+    type=int,
+    help="Triangle attention chunk size. Default is 128.",
+    default=128,
+)
+@click.option(
     "--output_format",
     type=click.Choice(["pdb", "mmcif"]),
     help="The output format to use for the predictions. Default is mmcif.",
@@ -565,6 +589,10 @@ def predict(
     step_scale: float = 1.638,
     write_full_pae: bool = False,
     write_full_pde: bool = False,
+    chunk_size_transition_z: int = 64,
+    chunk_size_transition_msa: int = 32,
+    chunk_size_outer_product: int = 4,
+    chunk_size_tri_attn: int = 128,
     output_format: Literal["pdb", "mmcif"] = "mmcif",
     num_workers: int = 2,
     override: bool = False,
@@ -663,6 +691,10 @@ def predict(
         "write_confidence_summary": True,
         "write_full_pae": write_full_pae,
         "write_full_pde": write_full_pde,
+        "chunk_size_transition_z": chunk_size_transition_z,
+        "chunk_size_transition_msa": chunk_size_transition_msa,
+        "chunk_size_outer_product": chunk_size_outer_product,
+        "chunk_size_tri_attn": chunk_size_tri_attn
     }
     diffusion_params = BoltzDiffusionParams()
     diffusion_params.step_scale = step_scale

--- a/src/boltz/model/model.py
+++ b/src/boltz/model/model.py
@@ -258,6 +258,10 @@ class Boltz1(LightningModule):
         multiplicity_diffusion_train: int = 1,
         diffusion_samples: int = 1,
         run_confidence_sequentially: bool = False,
+        chunk_size_transition_z: int = None,
+        chunk_size_transition_msa: int = None,
+        chunk_size_outer_product: int = None,
+        chunk_size_tri_attn: int = None,
     ) -> dict[str, Tensor]:
         dict_out = {}
 
@@ -301,7 +305,12 @@ class Boltz1(LightningModule):
 
                     # Compute pairwise stack
                     if not self.no_msa:
-                        z = z + self.msa_module(z, s_inputs, feats)
+                        z = z + self.msa_module(z, s_inputs, feats, 
+                                chunk_size_transition_z=chunk_size_transition_z, 
+                                chunk_size_transition_msa=chunk_size_transition_msa, 
+                                chunk_size_outer_product=chunk_size_outer_product, 
+                                chunk_size_tri_attn=chunk_size_tri_attn
+                            )
 
                     # Revert to uncompiled version for validation
                     if self.is_pairformer_compiled and not self.training:
@@ -309,7 +318,9 @@ class Boltz1(LightningModule):
                     else:
                         pairformer_module = self.pairformer_module
 
-                    s, z = pairformer_module(s, z, mask=mask, pair_mask=pair_mask)
+                    s, z = pairformer_module(s, z, mask=mask, pair_mask=pair_mask, 
+                                            chunk_size_transition_z=chunk_size_transition_z, 
+                                            chunk_size_tri_attn=chunk_size_tri_attn)
 
             pdistogram = self.distogram_module(z)
             dict_out = {"pdistogram": pdistogram}
@@ -358,6 +369,10 @@ class Boltz1(LightningModule):
                     pred_distogram_logits=dict_out["pdistogram"].detach(),
                     multiplicity=diffusion_samples,
                     run_sequentially=run_confidence_sequentially,
+                    chunk_size_transition_z=chunk_size_transition_z,
+                    chunk_size_transition_msa=chunk_size_transition_msa,
+                    chunk_size_outer_product=chunk_size_outer_product,
+                    chunk_size_tri_attn=chunk_size_tri_attn
                 )
             )
         if self.confidence_prediction and self.confidence_module.use_s_diffusion:
@@ -1123,6 +1138,10 @@ class Boltz1(LightningModule):
                 num_sampling_steps=self.predict_args["sampling_steps"],
                 diffusion_samples=self.predict_args["diffusion_samples"],
                 run_confidence_sequentially=True,
+                chunk_size_transition_z=self.predict_args["chunk_size_transition_z"],
+                chunk_size_transition_msa=self.predict_args["chunk_size_transition_msa"],
+                chunk_size_outer_product=self.predict_args["chunk_size_outer_product"],
+                chunk_size_tri_attn=self.predict_args["chunk_size_tri_attn"],            
             )
             pred_dict = {"exception": False}
             pred_dict["masks"] = batch["atom_pad_mask"]

--- a/src/boltz/model/modules/trunk.py
+++ b/src/boltz/model/modules/trunk.py
@@ -204,6 +204,10 @@ class MSAModule(nn.Module):
         z: Tensor,
         emb: Tensor,
         feats: Dict[str, Tensor],
+        chunk_size_transition_z: int = 64,
+        chunk_size_transition_msa: int = 32,
+        chunk_size_outer_product: int = 4,
+        chunk_size_tri_attn: int = 128
     ) -> Tensor:
         """Perform the forward pass.
 
@@ -226,10 +230,10 @@ class MSAModule(nn.Module):
         if not self.training:
             if z.shape[1] > const.chunk_size_threshold:
                 chunk_heads_pwa = True
-                chunk_size_transition_z = 64
-                chunk_size_transition_msa = 32
-                chunk_size_outer_product = 4
-                chunk_size_tri_attn = 128
+                chunk_size_transition_z = chunk_size_transition_z
+                chunk_size_transition_msa = chunk_size_transition_msa
+                chunk_size_outer_product = chunk_size_outer_product
+                chunk_size_tri_attn = chunk_size_tri_attn
             else:
                 chunk_heads_pwa = False
                 chunk_size_transition_z = None
@@ -497,7 +501,8 @@ class PairformerModule(nn.Module):
         z: Tensor,
         mask: Tensor,
         pair_mask: Tensor,
-        chunk_size_tri_attn: int = None,
+        chunk_size_transition_z: int = None,
+        chunk_size_tri_attn: int = 128,
     ) -> Tuple[Tensor, Tensor]:
         """Perform the forward pass.
 
@@ -521,14 +526,17 @@ class PairformerModule(nn.Module):
         """
         if not self.training:
             if z.shape[1] > const.chunk_size_threshold:
-                chunk_size_tri_attn = 128
+                chunk_size_tri_attn = chunk_size_tri_attn
+                chunk_size_transition_z = chunk_size_transition_z
             else:
                 chunk_size_tri_attn = 512
+                chunk_size_transition_z = None
         else:
             chunk_size_tri_attn = None
+            chunk_size_transition_z = None
 
         for layer in self.layers:
-            s, z = layer(s, z, mask, pair_mask, chunk_size_tri_attn)
+            s, z = layer(s, z, mask, pair_mask, chunk_size_transition_z, chunk_size_tri_attn)
         return s, z
 
 
@@ -594,6 +602,7 @@ class PairformerLayer(nn.Module):
         z: Tensor,
         mask: Tensor,
         pair_mask: Tensor,
+        chunk_size_transition_z: int = None,
         chunk_size_tri_attn: int = None,
     ) -> Tuple[Tensor, Tensor]:
         """Perform the forward pass."""
@@ -618,7 +627,7 @@ class PairformerLayer(nn.Module):
             chunk_size=chunk_size_tri_attn,
         )
 
-        z = z + self.transition_z(z)
+        z = z + self.transition_z(z, chunk_size_transition_z)
 
         # Compute sequence stack
         if not self.no_update_s:


### PR DESCRIPTION
Several issues here and on the slack are related to VRAM limitations:
#71, #83, #106, #167, #169, #197, #214

By tweaking the chunking parameters, you can significantly reduce the VRAM requirements. Using this strategy, I have modelled systems with 4000+ tokens on our H200s.

This PR:
- Provides chunking parameters as command-line arguments.
- Adds chunking to the PairformerLayer transition_z calculation (same as MSAlayer) which becomes a bottleneck at large system sizes.

Default behaviour should be consistent with the existing implementation.

- I did also have to enable PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True which may be worth documenting.
- Chunking will only occur above the chunk_size_threshold which may also be a useful command line argument.