### PR TITLE
raise exception instead of dict in OOM handler

### DIFF
--- a/src/boltz/model/model.py
+++ b/src/boltz/model/model.py
@@ -1158,7 +1158,7 @@ class Boltz1(LightningModule):
                 gc.collect()
                 return {"exception": True}
             else:
-                raise {"exception": True}
+                raise
 
     def configure_optimizers(self):
         """Configure the optimizer."""


### PR DESCRIPTION
The code attempted to 'raise' a dictionary when the error was not "out of memory,"
causing TypeError. This commit just ensures the original exception is re-raised properly.