### PR TITLE
Fixes issue when training Boltz-1x with steering

### DIFF
--- a/scripts/train/configs/confidence.yaml
+++ b/scripts/train/configs/confidence.yaml
@@ -74,6 +74,7 @@ data:
   max_dist: 22.0
   num_bins: 64
   atoms_per_window_queries: 32
+  compute_constraint_features: false
 
 model:
   _target_: boltz.model.model.Boltz1

--- a/scripts/train/configs/full.yaml
+++ b/scripts/train/configs/full.yaml
@@ -73,6 +73,7 @@ data:
   max_dist: 22.0
   num_bins: 64
   atoms_per_window_queries: 32
+  compute_constraint_features: false
 
 model:
   _target_: boltz.model.model.Boltz1

--- a/scripts/train/configs/structure.yaml
+++ b/scripts/train/configs/structure.yaml
@@ -72,6 +72,7 @@ data:
   max_dist: 22.0
   num_bins: 64
   atoms_per_window_queries: 32
+  compute_constraint_features: false
 
 model:
   _target_: boltz.model.model.Boltz1

--- a/src/boltz/data/module/training.py
+++ b/src/boltz/data/module/training.py
@@ -65,6 +65,7 @@ class DataConfig:
     binder_pocket_cutoff: float = 6.0
     binder_pocket_sampling_geometric_p: float = 0.0
     val_batch_size: int = 1
+    compute_constraint_features: bool = False
 
 
 @dataclass
@@ -614,6 +615,7 @@ class BoltzTrainingDataModule(pl.LightningDataModule):
             binder_pocket_cutoff=cfg.binder_pocket_cutoff,
             binder_pocket_sampling_geometric_p=cfg.binder_pocket_sampling_geometric_p,
             return_symmetries=cfg.return_train_symmetries,
+            compute_constraint_features=cfg.compute_constraint_features,
         )
         self._val_set = ValidationDataset(
             datasets=train if cfg.overfit is not None else val,
@@ -634,6 +636,7 @@ class BoltzTrainingDataModule(pl.LightningDataModule):
             return_symmetries=cfg.return_val_symmetries,
             binder_pocket_conditioned_prop=cfg.val_binder_pocket_conditioned_prop,
             binder_pocket_cutoff=cfg.binder_pocket_cutoff,
+            compute_constraint_features=cfg.compute_constraint_features,
         )
 
     def setup(self, stage: Optional[str] = None) -> None:


### PR DESCRIPTION
As noted by @jbderoo in a comment on PR #249 (and related to #243), training with `fk_steering` and `guidance_update` set to `True` results in a `KeyError`. This is because `compute_constraint_features` is set to `False` by default and couldn't be adjusted from within the training cfg file. 

This minimal PR adds `compute_constraint_features` as an arg to the `DataConfig` and wrapper datasets in `src/boltz/data/module/training.py` so users could train with steering if they want to.  

I'm not sure how useful/practical that would be, but now you can run it at least.

I also added the `compute_constraint_features` arg to the training cfg files, set to the default value of `False` since normally you wouldn't train with steering.

