### PR TITLE
Added a --use_cuda_bfloat16 option to the boltz predict command.

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -630,7 +630,7 @@ def predict(
     msa_server_url: str = "https://api.colabfold.com",
     msa_pairing_strategy: str = "greedy",
     no_potentials: bool = False,
-    use_cuda_bloat16: bool = False,
+    use_cuda_bfloat16: bool = False,
 ) -> None:
     """Run predictions with Boltz-1."""
     # If cpu, write a friendly warning


### PR DESCRIPTION
Fixes #263.  This allows predicting structures with 40% more residues without running out of GPU memory.  I tested on a half-dozen PDB structures and did not see any loss of accuracy.