### PR TITLE
Relax NumPy requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Boltz-1"
 readme = "README.md"
 dependencies = [
     "torch>=2.2",
-    "numpy==1.26.3",
+    "numpy>=1.26,<2.0",
     "hydra-core==1.3.2",
     "pytorch-lightning==2.4.0",
     "rdkit>=2024.3.2",


### PR DESCRIPTION
I encountered a dependency conflict installing `boltz` due to the current hard-pin on NumPy to `numpy==1.26.3`. This PR relaxes the requirement to `numpy>=1.26,<2.0`.