### PR TITLE
Added CI setup, fixed error with torch.load(), fixed GPU tests crash with runners & centralize pytest config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: tests
+
+on:
+  push:
+    paths-ignore: ['docs/**']
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false           # lets 3.11 fail without cancelling 3.9, etc.
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: "pip"    
+
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip
+        pip install .[test]      
+
+    - name: Run unit tests
+      run: pytest -m "not slow" --cov=src/boltz --cov-report=term-missing 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         pip install .[test]      
 
     - name: Run unit tests
-      run: pytest -m "not slow" --cov=src/boltz --cov-report=term-missing 
+      run: pytest -m "not slow and not gpu" --cov=src/boltz --cov-report=term-missing 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ boltz = "boltz.main:cli"
 
 [project.optional-dependencies]
 lint = ["ruff"]
-test = ["pytest", "requests"]
+test = [ "pytest", "requests", "pytest-cov"]
 
 [tool.ruff]
 src = ["src"]
@@ -80,8 +80,3 @@ keep-runtime-typing = true
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
-[tool.pytest.ini_options]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "regression",
-]

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,4 +9,5 @@ addopts =
 
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
+    gpu: test requires gpu (deselect with '-m' "not gpu")
     regression 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+filterwarnings = 
+    ignore::DeprecationWarning 
+
+addopts = 
+    --strict-markers
+    --strict-config
+    -ra
+
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    regression 

--- a/tests/model/layers/test_triangle_attention.py
+++ b/tests/model/layers/test_triangle_attention.py
@@ -1,9 +1,10 @@
 import pytorch_lightning
 import torch
 import torch.nn as nn
-
+import pytest
 import unittest
-
+if not torch.cuda.is_available():
+    pytest.skip("no GPU available, skipping GPU-only tests", allow_module_level=True)
 from boltz.model.layers.triangular_attention.attention import TriangleAttention
 
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -37,7 +37,7 @@ class RegressionTester(unittest.TestCase):
             regression_feats_url = "https://www.dropbox.com/scl/fi/1avbcvoor5jcnvpt07tp6/ligand_regression_feats.pkl?rlkey=iwtm9gpxgrbp51jbizq937pqf&st=jnbky253&dl=1"
             test_utils.download_file(regression_feats_url, regression_feats_path)
 
-        regression_feats = torch.load(regression_feats_path, map_location=device)
+        regression_feats = torch.load(regression_feats_path, map_location=device, weights_only=False)
         model_module: nn.Module = Boltz1.load_from_checkpoint(checkpoint, map_location=device)
         model_module.to(device)
         model_module.eval()
@@ -66,7 +66,7 @@ class RegressionTester(unittest.TestCase):
 
         assert torch.allclose(exp_rel_pos_encoding, act_rel_pos_encoding, atol=1e-5)
 
-    @pytest.mark.slow
+    # @pytest.mark.slow
     def test_structure_output(self):
         exp_structure_output = self.regression_feats["structure_output"]
         s = self.regression_feats["s"]

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -11,9 +11,11 @@ import unittest
 
 from lightning_fabric import seed_everything
 
-from boltz.main import MODEL_URL
-from boltz.model.model import Boltz1
 
+if not torch.cuda.is_available():
+    pytest.skip("no GPU available, skipping GPU-only tests", allow_module_level=True)
+from boltz.model.model import Boltz1
+from boltz.main import MODEL_URL
 import test_utils
 
 tests_dir = os.path.dirname(os.path.abspath(__file__))
@@ -66,7 +68,7 @@ class RegressionTester(unittest.TestCase):
 
         assert torch.allclose(exp_rel_pos_encoding, act_rel_pos_encoding, atol=1e-5)
 
-    # @pytest.mark.slow
+    @pytest.mark.slow
     def test_structure_output(self):
         exp_structure_output = self.regression_feats["structure_output"]
         s = self.regression_feats["s"]


### PR DESCRIPTION
PR to create the CI setup, fix some minor issue with torch and centrilized the testing config. 
1. Added a CI workflow.
2. Skipped tests that require CUDA through imports so they don’t crash on GitHub runners
3. Added centralized pytest configuration in `pytest.ini`  and removed the old tool.pytest.ini_options section from `pyproject.toml`
4. Fixed error with torch.load when loading the weights in the tests