### PR TITLE
Allow Boltz 1.0.0 to install on Mac and Windows by requiring trifast only on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pyyaml==6.0.2",
     "biopython==1.84",
     "scipy==1.13.1",
-    "trifast>=0.1.11",
+    'trifast>=0.1.11 ; platform_system == "Linux"',
     "numba==0.61.0",
 ]
 

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -724,8 +724,10 @@ def predict(
     diffusion_params = BoltzDiffusionParams()
     diffusion_params.step_scale = step_scale
 
-    pairformer_args = PairformerArgs(use_trifast=(accelerator != "cpu"))
-    msa_module_args = MSAModuleArgs(use_trifast=(accelerator != "cpu"))
+    from sys import platform
+    use_trifast = (platform == 'linux' && accelerator != "cpu")
+    pairformer_args = PairformerArgs(use_trifast=use_trifast)
+    msa_module_args = MSAModuleArgs(use_trifast=use_trifast)
 
     steering_args = BoltzSteeringParams()
     if no_potentials:

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -725,7 +725,7 @@ def predict(
     diffusion_params.step_scale = step_scale
 
     from sys import platform
-    use_trifast = (platform == 'linux' && accelerator != "cpu")
+    use_trifast = (platform == 'linux' and accelerator != "cpu")
     pairformer_args = PairformerArgs(use_trifast=use_trifast)
     msa_module_args = MSAModuleArgs(use_trifast=use_trifast)
 


### PR DESCRIPTION
Fixes #275.

Changes pyproject.toml so PyPi trifast is only requires on Linux since trifast requires triton which is only supported on Linux.  Also makes main.py predict() method set use_trifast = False on Mac and Windows.
