### PR TITLE
Abstract diagrams for the boltz codebase

### DIFF
--- a/.codeboarding/Application Orchestration.md
+++ b/.codeboarding/Application Orchestration.md
@@ -1,0 +1,119 @@
+```mermaid
+graph LR
+    Application_Orchestration["Application Orchestration"]
+    Input_Data_Processing["Input Data Processing"]
+    Core_Data_Models["Core Data Models"]
+    Inference_Data_Preparation["Inference Data Preparation"]
+    Prediction_Output_Management["Prediction Output Management"]
+    Model_Prediction_Engines["Model Prediction Engines"]
+    Application_Orchestration -- "orchestrates" --> Input_Data_Processing
+    Application_Orchestration -- "manages data structures from" --> Core_Data_Models
+    Application_Orchestration -- "initiates data loading and featurization for" --> Inference_Data_Preparation
+    Application_Orchestration -- "directs output writing to" --> Prediction_Output_Management
+    Application_Orchestration -- "utilizes" --> Model_Prediction_Engines
+    Input_Data_Processing -- "generates data instances for" --> Core_Data_Models
+    Inference_Data_Preparation -- "processes data instances from" --> Core_Data_Models
+    Prediction_Output_Management -- "serializes data instances from" --> Core_Data_Models
+    Model_Prediction_Engines -- "consumes data from" --> Inference_Data_Preparation
+    Model_Prediction_Engines -- "produces data for" --> Prediction_Output_Management
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the core components and their interactions within the Boltz application, focusing on the flow from input data processing to model prediction and output management. The Application Orchestration component acts as the central control unit, coordinating the entire workflow by interacting with specialized components for data parsing, model inference preparation, prediction execution, and result serialization. Data models serve as the foundational structures for data exchange across these components.
+
+### Application Orchestration
+Serves as the central control unit for the Boltz application, managing the overall workflow from input processing to model prediction. It coordinates data flow and execution across different modules.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L311-L352" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:filter_inputs_structure` (311:352)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L477-L605" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:process_input` (477:605)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L933-L999" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:predict` (933:999)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L159-L192" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.download_boltz1` (159:192)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L196-L250" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.download_boltz2` (196:250)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L273-L308" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.check_inputs` (273:308)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L609-L728" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.process_inputs` (609:728)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L55-L63" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.BoltzProcessedInput` (55:63)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L128-L143" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.Boltz2DiffusionParams` (128:143)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L79-L87" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.PairformerArgsV2` (79:87)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L108-L124" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.BoltzDiffusionParams` (108:124)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L67-L75" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.PairformerArgs` (67:75)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L91-L104" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.MSAModuleArgs` (91:104)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L147-L155" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.BoltzSteeringParams` (147:155)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L355-L401" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main.filter_inputs_affinity` (355:401)</a>
+
+
+### Input Data Processing
+This component is responsible for parsing various raw input file formats (FASTA, YAML, A3M, CSV) into a standardized internal data representation. It ensures that external data is correctly interpreted and structured for further processing.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/fasta.py#L11-L138" target="_blank" rel="noopener noreferrer">`boltz.data.parse.fasta.parse_fasta` (11:138)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/yaml.py#L10-L68" target="_blank" rel="noopener noreferrer">`boltz.data.parse.yaml.parse_yaml` (10:68)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/a3m.py#L104-L134" target="_blank" rel="noopener noreferrer">`boltz.data.parse.a3m.parse_a3m` (104:134)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/csv.py#L11-L100" target="_blank" rel="noopener noreferrer">`boltz.data.parse.csv.parse_csv` (11:100)</a>
+
+
+### Core Data Models
+This component defines the fundamental data structures and serialization mechanisms used throughout the Boltz system for representing molecular structures, multiple sequence alignments (MSAs), and input records. It facilitates data exchange and persistence.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L647-L683" target="_blank" rel="noopener noreferrer">`boltz.data.types.Manifest` (647:683)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L15-L44" target="_blank" rel="noopener noreferrer">`boltz.data.types.NumpySerializable` (15:44)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L47-L78" target="_blank" rel="noopener noreferrer">`boltz.data.types.JSONSerializable` (47:78)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L169-L319" target="_blank" rel="noopener noreferrer">`boltz.data.types.Structure` (169:319)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L323-L441" target="_blank" rel="noopener noreferrer">`boltz.data.types.StructureV2` (323:441)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L469-L474" target="_blank" rel="noopener noreferrer">`boltz.data.types.MSA` (469:474)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L566-L576" target="_blank" rel="noopener noreferrer">`boltz.data.types.Record` (566:576)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L692-L700" target="_blank" rel="noopener noreferrer">`boltz.data.types.Input` (692:700)</a>
+
+
+### Inference Data Preparation
+This component handles the loading, tokenization, and featurization of data specifically for the prediction models. It prepares the input data in the correct format and with the necessary features for the inference process.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L313-L429" target="_blank" rel="noopener noreferrer">`boltz.data.module.inferencev2.Boltz2InferenceDataModule` (313:429)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L223-L307" target="_blank" rel="noopener noreferrer">`boltz.data.module.inference.BoltzInferenceDataModule` (223:307)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L27-L109" target="_blank" rel="noopener noreferrer">`boltz.data.module.inferencev2.Boltz2InferenceDataModule.load_input` (27:109)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L112-L154" target="_blank" rel="noopener noreferrer">`boltz.data.module.inferencev2.Boltz2InferenceDataModule.collate` (112:154)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L157-L310" target="_blank" rel="noopener noreferrer">`boltz.data.module.inferencev2.Boltz2InferenceDataModule.PredictionDataset` (157:310)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L25-L74" target="_blank" rel="noopener noreferrer">`boltz.data.module.inference.BoltzInferenceDataModule.load_input` (25:74)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L77-L118" target="_blank" rel="noopener noreferrer">`boltz.data.module.inference.BoltzInferenceDataModule.collate` (77:118)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L121-L220" target="_blank" rel="noopener noreferrer">`boltz.data.module.inference.BoltzInferenceDataModule.PredictionDataset` (121:220)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L349-L396" target="_blank" rel="noopener noreferrer">`boltz.data.tokenize.boltz2.Boltz2Tokenizer` (349:396)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz.py#L32-L195" target="_blank" rel="noopener noreferrer">`boltz.data.tokenize.boltz.BoltzTokenizer` (32:195)</a>
+- `boltz.data.feature.featurizerv2.Boltz2Featurizer` (full file reference)
+- `boltz.data.feature.featurizer.BoltzFeaturizer` (full file reference)
+
+
+### Prediction Output Management
+This component is dedicated to writing the results of the prediction process to disk. It supports various output formats for structural predictions and handles the saving of affinity prediction summaries.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/writer.py#L17-L254" target="_blank" rel="noopener noreferrer">`boltz.data.write.writer.BoltzWriter` (17:254)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/writer.py#L257-L330" target="_blank" rel="noopener noreferrer">`boltz.data.write.writer.BoltzAffinityWriter` (257:330)</a>
+
+
+### Model Prediction Engines
+This component encapsulates the core prediction models (Boltz1 and Boltz2) responsible for performing the actual molecular structure and affinity predictions. It takes prepared input data and generates the predicted outputs.
+
+
+**Related Classes/Methods**:
+
+- `boltz.model.models.boltz1` (full file reference)
+- `boltz.model.models.boltz2` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Boltz Core Models.md
+++ b/.codeboarding/Boltz Core Models.md
@@ -1,0 +1,331 @@
+```mermaid
+graph LR
+    Main_Application_Orchestration["Main Application Orchestration"]
+    Boltz_Model_Architectures["Boltz Model Architectures"]
+    Diffusion_Process_Core["Diffusion Process Core"]
+    Confidence_Affinity_Prediction_Heads["Confidence & Affinity Prediction Heads"]
+    Core_Neural_Network_Layers["Core Neural Network Layers"]
+    Feature_Encoding_Trunk_Processing["Feature Encoding & Trunk Processing"]
+    Transformer_Blocks["Transformer Blocks"]
+    Loss_Calculation["Loss Calculation"]
+    Utility_Initialization_Functions["Utility & Initialization Functions"]
+    Optimization_Callbacks["Optimization & Callbacks"]
+    Data_Processing_I_O["Data Processing & I/O"]
+    Main_Application_Orchestration -- "Preprocesses and manages" --> Data_Processing_I_O
+    Main_Application_Orchestration -- "Writes output via" --> Data_Processing_I_O
+    Main_Application_Orchestration -- "Loads and executes" --> Boltz_Model_Architectures
+    Main_Application_Orchestration -- "Downloads model weights for" --> Boltz_Model_Architectures
+    Boltz_Model_Architectures -- "Utilizes for structure generation" --> Diffusion_Process_Core
+    Boltz_Model_Architectures -- "Integrates diffusion logic from" --> Diffusion_Process_Core
+    Boltz_Model_Architectures -- "Feeds data to for prediction" --> Confidence_Affinity_Prediction_Heads
+    Boltz_Model_Architectures -- "Receives predictions from" --> Confidence_Affinity_Prediction_Heads
+    Boltz_Model_Architectures -- "Processes input features using" --> Feature_Encoding_Trunk_Processing
+    Boltz_Model_Architectures -- "Builds representations with" --> Feature_Encoding_Trunk_Processing
+    Boltz_Model_Architectures -- "Computes training losses via" --> Loss_Calculation
+    Boltz_Model_Architectures -- "Configures training with" --> Optimization_Callbacks
+    Diffusion_Process_Core -- "Composed of" --> Core_Neural_Network_Layers
+    Diffusion_Process_Core -- "Leverages for transformations" --> Core_Neural_Network_Layers
+    Confidence_Affinity_Prediction_Heads -- "Built upon" --> Core_Neural_Network_Layers
+    Feature_Encoding_Trunk_Processing -- "Constructed from" --> Core_Neural_Network_Layers
+    Feature_Encoding_Trunk_Processing -- "Applies transformations using" --> Core_Neural_Network_Layers
+    Core_Neural_Network_Layers -- "Initializes weights using" --> Utility_Initialization_Functions
+    Core_Neural_Network_Layers -- "Uses utility functions from" --> Utility_Initialization_Functions
+    Diffusion_Process_Core -- "Applies random augmentations via" --> Utility_Initialization_Functions
+    Loss_Calculation -- "Depends on processed data from" --> Data_Processing_I_O
+    Data_Processing_I_O -- "Uses utility functions for data manipulation" --> Utility_Initialization_Functions
+    Diffusion_Process_Core -- "Utilizes for internal transformations" --> Transformer_Blocks
+    Feature_Encoding_Trunk_Processing -- "Composed of" --> Transformer_Blocks
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Boltz system is designed for predicting molecular structures, confidence metrics, and binding affinities. It orchestrates a complex pipeline that begins with input data processing, including validation and MSA generation. The system then loads and utilizes pre-trained Boltz neural network models (Boltz1 and Boltz2) which incorporate sophisticated diffusion mechanisms for structure generation, alongside dedicated modules for confidence and affinity predictions. The core of the models relies on various neural network layers and transformer blocks for feature encoding and trunk processing. During training, it leverages specific loss functions and optimization strategies. Finally, it handles the output of predictions by writing them to appropriate file formats.
+
+### Main Application Orchestration
+This component orchestrates the entire prediction pipeline. It handles input data validation, preprocessing (MSA generation, parsing), model downloading, model loading, and writing the final predictions. It acts as the central control flow for the Boltz application.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L933-L999" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:predict` (933:999)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L159-L192" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:download_boltz1` (159:192)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L196-L250" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:download_boltz2` (196:250)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L273-L308" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:check_inputs` (273:308)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L609-L728" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:process_inputs` (609:728)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L311-L352" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:filter_inputs_structure` (311:352)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L355-L401" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:filter_inputs_affinity` (355:401)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/writer.py#L17-L254" target="_blank" rel="noopener noreferrer">`boltz.data.write.writer.BoltzWriter` (17:254)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/writer.py#L257-L330" target="_blank" rel="noopener noreferrer">`boltz.data.write.writer.BoltzAffinityWriter` (257:330)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L313-L429" target="_blank" rel="noopener noreferrer">`boltz.data.module.inferencev2.Boltz2InferenceDataModule` (313:429)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L223-L307" target="_blank" rel="noopener noreferrer">`boltz.data.module.inference.BoltzInferenceDataModule` (223:307)</a>
+
+
+### Boltz Model Architectures
+This component encapsulates the high-level structure and behavior of Boltz1 and Boltz2 models, including their training, validation, and prediction loops.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/models/boltz1.py#L16-L300" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.models.boltz1.Boltz1` (16:300)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/models/boltz2.py#L16-L300" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.models.boltz2.Boltz2` (16:300)</a>
+
+
+### Diffusion Process Core
+This component implements the central diffusion mechanism for generating molecular structures, including noise handling, sampling, and potential-based steering.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusionv2.py#L38-L176" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusionv2.DiffusionModule` (38:176)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusionv2.py#L179-L677" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusionv2.AtomDiffusion` (179:677)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusion.py#L41-L229" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusion.DiffusionModule` (41:229)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusion.py#L284-L844" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusion.AtomDiffusion` (284:844)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusion.py#L232-L281" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusion.OutTokenFeatUpdate` (232:281)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L417-L482" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials:get_potentials` (417:482)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L318-L347" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.SymmetricChainCOMPotential` (318:347)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L257-L315" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.VDWOverlapPotential` (257:315)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L245-L254" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.ConnectionsPotential` (245:254)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L219-L242" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.PoseBustersPotential` (219:242)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L371-L388" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.ChiralAtomPotential` (371:388)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L350-L368" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.StereoBondPotential` (350:368)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L391-L414" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.PlanarBondPotential` (391:414)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/schedules.py#L8-L18" target="_blank" rel="noopener noreferrer">`boltz.model.potentials.schedules.ExponentialInterpolation` (8:18)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/schedules.py#L20-L32" target="_blank" rel="noopener noreferrer">`boltz.model.potentials.schedules.PiecewiseStepFunction` (20:32)</a>
+
+
+### Confidence & Affinity Prediction Heads
+Modules specifically designed for predicting confidence metrics (pLDDT, pAE) and molecular binding affinity.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidencev2.py#L19-L237" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidencev2.ConfidenceModule` (19:237)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidencev2.py#L240-L503" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidencev2.ConfidenceHeads` (240:503)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidence.py#L20-L334" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidence.ConfidenceModule` (20:334)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidence.py#L337-L481" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidence.ConfidenceHeads` (337:481)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/affinity.py#L34-L135" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.affinity.AffinityModule` (34:135)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/affinity.py#L138-L219" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.affinity.AffinityHeadsTransformer` (138:219)</a>
+
+
+### Core Neural Network Layers
+Fundamental building blocks of the neural networks, including various attention mechanisms, triangular multiplications, and transition blocks.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/pairformer.py#L21-L107" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.pairformer.PairformerLayer` (21:107)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/pairformer.py#L110-L195" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.pairformer.PairformerModule` (110:195)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/pairformer.py#L198-L257" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.pairformer.PairformerNoSeqLayer` (198:257)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/pairformer.py#L260-L314" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.pairformer.PairformerNoSeqModule` (260:314)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_mult.py#L7-L74" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_mult.TriangleMultiplicationOutgoing` (7:74)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_mult.py#L77-L144" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_mult.TriangleMultiplicationIncoming` (77:144)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/attention.py#L33-L162" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.attention.TriangleAttention` (33:162)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/attention.py#L169-L172" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.attention.TriangleAttentionEndingNode` (169:172)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/attention.py#L8-L132" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.attention.AttentionPairBias` (8:132)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/attentionv2.py#L10-L111" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.attentionv2.AttentionPairBias` (10:111)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/transition.py#L8-L78" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.transition.Transition` (8:78)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/pair_averaging.py#L7-L135" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.pair_averaging.PairWeightedAveraging` (7:135)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/outer_product_mean.py#L7-L98" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.outer_product_mean.OuterProductMean` (7:98)</a>
+
+
+### Feature Encoding & Trunk Processing
+Modules responsible for encoding input features (single, pairwise, atom-level) and the main 'trunk' of the network that processes these features through a series of layers.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L136-L206" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.SingleConditioning` (136:206)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L209-L260" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.PairwiseConditioning` (209:260)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L288-L540" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.AtomAttentionEncoder` (288:540)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L543-L639" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.AtomAttentionDecoder` (543:639)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L123-L177" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.SingleConditioning` (123:177)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L180-L217" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.PairwiseConditioning` (180:217)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L245-L411" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.AtomEncoder` (245:411)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L414-L492" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.AtomAttentionEncoder` (414:492)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L495-L565" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.AtomAttentionDecoder` (495:565)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L24-L113" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.InputEmbedder` (24:113)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L116-L289" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.MSAModule` (116:289)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L292-L421" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.MSALayer` (292:421)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L424-L549" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.PairformerModule` (424:549)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L552-L648" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.PairformerLayer` (552:648)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L21-L65" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.ContactConditioning` (21:65)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L68-L208" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.InputEmbedder` (68:208)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L211-L358" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.TemplateModule` (211:358)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L361-L509" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.TemplateV2Module` (361:509)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L512-L669" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.MSAModule` (512:669)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L672-L758" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.MSALayer` (672:758)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L794-L828" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.DistogramModule` (794:828)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L761-L791" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.BFactorModule` (761:791)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusion_conditioning.py#L13-L116" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusion_conditioning.DiffusionConditioning` (13:116)</a>
+
+
+### Transformer Blocks
+Reusuable transformer-based blocks used within various modules for sequence and pair transformations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L34-L65" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.ConditionedTransitionBlock` (34:65)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L68-L137" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.DiffusionTransformer` (68:137)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L140-L208" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.DiffusionTransformerLayer` (140:208)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L211-L261" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.AtomTransformer` (211:261)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L17-L31" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.AdaLN` (17:31)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformers.py#L44-L87" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformers.ConditionedTransitionBlock` (44:87)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformers.py#L90-L177" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformers.DiffusionTransformer` (90:177)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformers.py#L180-L249" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformers.DiffusionTransformerLayer` (180:249)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformers.py#L252-L322" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformers.AtomTransformer` (252:322)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformers.py#L17-L41" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformers.AdaLN` (17:41)</a>
+
+
+### Loss Calculation
+Provides functions for computing various loss terms used during model training.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidencev2.py#L8-L87" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidencev2:confidence_loss` (8:87)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidencev2.py#L207-L292" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidencev2:plddt_loss` (207:292)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidencev2.py#L432-L513" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidencev2:pae_loss` (432:513)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidencev2.py#L542-L621" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidencev2:pde_loss` (542:621)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidencev2.py#L141-L204" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidencev2:get_target_lddt` (141:204)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidencev2.py#L355-L429" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidencev2:get_target_pae` (355:429)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidence.py#L7-L84" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidence.confidence_loss` (7:84)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidence.py#L136-L239" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidence.plddt_loss` (136:239)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidence.py#L310-L421" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidence.pae_loss` (310:421)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidence.py#L494-L590" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidence.compute_frame_pred` (494:590)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/diffusionv2.py#L9-L79" target="_blank" rel="noopener noreferrer">`boltz.model.loss.diffusionv2.weighted_rigid_align` (9:79)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/diffusionv2.py#L82-L134" target="_blank" rel="noopener noreferrer">`boltz.model.loss.diffusionv2.smooth_lddt_loss` (82:134)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/diffusion.py#L8-L94" target="_blank" rel="noopener noreferrer">`boltz.model.loss.diffusion.weighted_rigid_align` (8:94)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/diffusion.py#L97-L171" target="_blank" rel="noopener noreferrer">`boltz.model.loss.diffusion.smooth_lddt_loss` (97:171)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/distogramv2.py#L5-L105" target="_blank" rel="noopener noreferrer">`boltz.model.loss.distogramv2.distogram_loss` (5:105)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/distogram.py#L5-L48" target="_blank" rel="noopener noreferrer">`boltz.model.loss.distogram.distogram_loss` (5:48)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/bfactor.py#L5-L49" target="_blank" rel="noopener noreferrer">`boltz.model.loss.bfactor.bfactor_loss_fn` (5:49)</a>
+- `boltz.model.loss.validation.factored_token_lddt_dist_loss` (full file reference)
+- `boltz.model.loss.validation.factored_lddt_loss` (full file reference)
+- `boltz.model.loss.validation.compute_plddt_mae` (full file reference)
+- `boltz.model.loss.validation.compute_pde_mae` (full file reference)
+- `boltz.model.loss.validation.compute_pae_mae` (full file reference)
+- `boltz.model.loss.validation.weighted_minimum_rmsd` (full file reference)
+
+
+### Utility & Initialization Functions
+General utility functions, mathematical operations, and various weight initialization strategies used across the model's layers and modules.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L47-L58" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:trunc_normal_init_` (47:58)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L61-L62" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:lecun_normal_init_` (61:62)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L65-L66" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:he_normal_init_` (65:66)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L88-L90" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:bias_init_one_` (88:90)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L83-L85" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:bias_init_zero_` (83:85)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L69-L70" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:glorot_uniform_init_` (69:70)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L78-L80" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:gating_init_` (78:80)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L93-L94" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:normal_init_` (93:94)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L73-L75" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize:final_init_` (73:75)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L32-L44" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize._calculate_fan` (32:44)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L25-L29" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize._prod` (25:29)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L21-L22" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:default` (21:22)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L17-L18" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:exists` (17:18)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L46-L53" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:compute_random_augmentation` (46:53)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L56-L64" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:randomly_rotate` (56:64)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L67-L100" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:center_random_augmentation` (67:100)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L263-L284" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:random_quaternions` (263:284)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L287-L303" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:random_rotations` (287:303)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L231-L260" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:quaternion_to_matrix` (231:260)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L25-L26" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:log` (25:26)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L29-L35" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils.SwiGLU` (29:35)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L103-L207" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils.ExponentialMovingAverage` (103:207)</a>
+
+
+### Optimization & Callbacks
+Handles optimization strategies and training callbacks, such as learning rate scheduling and Exponential Moving Average (EMA).
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/optim/scheduler.py#L4-L99" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.optim.scheduler.AlphaFoldLRScheduler` (4:99)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/optim/ema.py#L14-L389" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.optim.ema.EMA` (14:389)</a>
+
+
+### Data Processing & I/O
+This component is responsible for all data-related operations, including cropping, feature extraction, filtering, parsing various input formats (A3M, CSV, FASTA, MMCIF, YAML), sampling, tokenization, and writing output files (MMCIF, PDB). It ensures data is correctly prepared for model inference and training, and results are stored appropriately.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/affinity.py#L11-L164" target="_blank" rel="noopener noreferrer">`boltz.data.crop.affinity.AffinityCropper` (11:164)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/boltz.py#L127-L296" target="_blank" rel="noopener noreferrer">`boltz.data.crop.boltz.BoltzCropper` (127:296)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/cropper.py#L9-L45" target="_blank" rel="noopener noreferrer">`boltz.data.crop.cropper.Cropper` (9:45)</a>
+- `boltz.data.feature.featurizer.BoltzFeaturizer` (full file reference)
+- `boltz.data.feature.featurizerv2.Boltz2Featurizer` (full file reference)
+- `boltz.data.feature.symmetry.Symmetry` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/date.py#L8-L76" target="_blank" rel="noopener noreferrer">`boltz.data.filter.dynamic.date.DateFilter` (8:76)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/filter.py#L6-L24" target="_blank" rel="noopener noreferrer">`boltz.data.filter.dynamic.filter.DynamicFilter` (6:24)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/max_residues.py#L5-L37" target="_blank" rel="noopener noreferrer">`boltz.data.filter.dynamic.max_residues.MaxResiduesFilter` (5:37)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/resolution.py#L5-L34" target="_blank" rel="noopener noreferrer">`boltz.data.filter.dynamic.resolution.ResolutionFilter` (5:34)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/size.py#L5-L38" target="_blank" rel="noopener noreferrer">`boltz.data.filter.dynamic.size.SizeFilter` (5:38)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/subset.py#L7-L42" target="_blank" rel="noopener noreferrer">`boltz.data.filter.dynamic.subset.SubsetFilter` (7:42)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/filter.py#L8-L26" target="_blank" rel="noopener noreferrer">`boltz.data.filter.static.filter.StaticFilter` (8:26)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/ligand.py#L8-L37" target="_blank" rel="noopener noreferrer">`boltz.data.filter.static.ligand.ExcludedLigands` (8:37)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L175-L299" target="_blank" rel="noopener noreferrer">`boltz.data.filter.static.polymer.ClashingChainsFilter` (175:299)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L104-L162" target="_blank" rel="noopener noreferrer">`boltz.data.filter.static.polymer.ConsecutiveCA` (104:162)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L12-L62" target="_blank" rel="noopener noreferrer">`boltz.data.filter.static.polymer.MinimumLengthFilter` (12:62)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L65-L101" target="_blank" rel="noopener noreferrer">`boltz.data.filter.static.polymer.UnknownFilter` (65:101)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L223-L307" target="_blank" rel="noopener noreferrer">`boltz.data.module.inference.BoltzInferenceDataModule` (223:307)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L121-L220" target="_blank" rel="noopener noreferrer">`boltz.data.module.inference.PredictionDataset` (121:220)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L313-L429" target="_blank" rel="noopener noreferrer">`boltz.data.module.inferencev2.Boltz2InferenceDataModule` (313:429)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L157-L310" target="_blank" rel="noopener noreferrer">`boltz.data.module.inferencev2.PredictionDataset` (157:310)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L491-L684" target="_blank" rel="noopener noreferrer">`boltz.data.module.training.BoltzTrainingDataModule` (491:684)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L36-L67" target="_blank" rel="noopener noreferrer">`boltz.data.module.training.DataConfig` (36:67)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L71-L81" target="_blank" rel="noopener noreferrer">`boltz.data.module.training.Dataset` (71:81)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L22-L32" target="_blank" rel="noopener noreferrer">`boltz.data.module.training.DatasetConfig` (22:32)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L186-L335" target="_blank" rel="noopener noreferrer">`boltz.data.module.training.TrainingDataset` (186:335)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L338-L488" target="_blank" rel="noopener noreferrer">`boltz.data.module.training.ValidationDataset` (338:488)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L467-L660" target="_blank" rel="noopener noreferrer">`boltz.data.module.trainingv2.BoltzTrainingDataModule` (467:660)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L36-L67" target="_blank" rel="noopener noreferrer">`boltz.data.module.trainingv2.DataConfig` (36:67)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L71-L81" target="_blank" rel="noopener noreferrer">`boltz.data.module.trainingv2.Dataset` (71:81)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L22-L32" target="_blank" rel="noopener noreferrer">`boltz.data.module.trainingv2.DatasetConfig` (22:32)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L168-L314" target="_blank" rel="noopener noreferrer">`boltz.data.module.trainingv2.TrainingDataset` (168:314)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L317-L464" target="_blank" rel="noopener noreferrer">`boltz.data.module.trainingv2.ValidationDataset` (317:464)</a>
+- `boltz.data.mol.Mol` (full file reference)
+- `boltz.data.parse.a3m.A3MParser` (full file reference)
+- `boltz.data.parse.csv.CSVParser` (full file reference)
+- `boltz.data.parse.fasta.FastaParser` (full file reference)
+- `boltz.data.parse.mmcif.MMCIFParser` (full file reference)
+- `boltz.data.parse.mmcif.ParsedStructure` (full file reference)
+- `boltz.data.parse.mmcif_with_constraints.MMCIFWithConstraintsParser` (full file reference)
+- `boltz.data.parse.mmcif_with_constraints.ParsedStructure` (full file reference)
+- `boltz.data.parse.schema.SchemaParser` (full file reference)
+- `boltz.data.parse.yaml.YAMLParser` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/cluster.py#L163-L283" target="_blank" rel="noopener noreferrer">`boltz.data.sample.cluster.ClusterSampler` (163:283)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/distillation.py#L9-L57" target="_blank" rel="noopener noreferrer">`boltz.data.sample.distillation.DistillationSampler` (9:57)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/random.py#L10-L39" target="_blank" rel="noopener noreferrer">`boltz.data.sample.random.RandomSampler` (10:39)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/sampler.py#L11-L26" target="_blank" rel="noopener noreferrer">`boltz.data.sample.sampler.Sample` (11:26)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/sampler.py#L29-L49" target="_blank" rel="noopener noreferrer">`boltz.data.sample.sampler.Sampler` (29:49)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz.py#L32-L195" target="_blank" rel="noopener noreferrer">`boltz.data.tokenize.boltz.BoltzTokenizer` (32:195)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L349-L396" target="_blank" rel="noopener noreferrer">`boltz.data.tokenize.boltz2.Boltz2Tokenizer` (349:396)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/tokenizer.py#L6-L24" target="_blank" rel="noopener noreferrer">`boltz.data.tokenize.tokenizer.Tokenizer` (6:24)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L692-L700" target="_blank" rel="noopener noreferrer">`boltz.data.types.Input` (692:700)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L47-L78" target="_blank" rel="noopener noreferrer">`boltz.data.types.JSONSerializable` (47:78)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L469-L474" target="_blank" rel="noopener noreferrer">`boltz.data.types.MSA` (469:474)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L647-L683" target="_blank" rel="noopener noreferrer">`boltz.data.types.Manifest` (647:683)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L15-L44" target="_blank" rel="noopener noreferrer">`boltz.data.types.NumpySerializable` (15:44)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L566-L576" target="_blank" rel="noopener noreferrer">`boltz.data.types.Record` (566:576)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L618-L626" target="_blank" rel="noopener noreferrer">`boltz.data.types.ResidueConstraints` (618:626)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L169-L319" target="_blank" rel="noopener noreferrer">`boltz.data.types.Structure` (169:319)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L483-L494" target="_blank" rel="noopener noreferrer">`boltz.data.types.StructureInfo` (483:494)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L323-L441" target="_blank" rel="noopener noreferrer">`boltz.data.types.StructureV2` (323:441)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L635-L643" target="_blank" rel="noopener noreferrer">`boltz.data.types.Target` (635:643)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L765-L777" target="_blank" rel="noopener noreferrer">`boltz.data.types.Tokenized` (765:777)</a>
+- `boltz.data.write.mmcif.MMCIFWriter` (full file reference)
+- `boltz.data.write.pdb.PDBWriter` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/writer.py#L257-L330" target="_blank" rel="noopener noreferrer">`boltz.data.write.writer.BoltzAffinityWriter` (257:330)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/writer.py#L17-L254" target="_blank" rel="noopener noreferrer">`boltz.data.write.writer.BoltzWriter` (17:254)</a>
+- `boltz.data.write.writer.Writer` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data Management & Augmentation.md
+++ b/.codeboarding/Data Management & Augmentation.md
@@ -1,0 +1,182 @@
+```mermaid
+graph LR
+    DataSampling["DataSampling"]
+    DataCropping["DataCropping"]
+    DataFiltering["DataFiltering"]
+    DataManifestAndTypes["DataManifestAndTypes"]
+    TrainingDataModule["TrainingDataModule"]
+    InferenceDataModule["InferenceDataModule"]
+    FeatureEngineering["FeatureEngineering"]
+    DataTokenization["DataTokenization"]
+    DataParsing["DataParsing"]
+    DataWriting["DataWriting"]
+    TrainingDataModule -- "loads data manifests from" --> DataManifestAndTypes
+    TrainingDataModule -- "incorporates symmetry features from" --> FeatureEngineering
+    DataSampling -- "processes data structures defined in" --> DataManifestAndTypes
+    DataCropping -- "operates on data structures defined in" --> DataManifestAndTypes
+    InferenceDataModule -- "prepares data using types from" --> DataManifestAndTypes
+    TrainingDataModule -- "utilizes" --> DataCropping
+    TrainingDataModule -- "utilizes" --> DataSampling
+    TrainingDataModule -- "utilizes" --> DataFiltering
+    TrainingDataModule -- "utilizes" --> DataTokenization
+    TrainingDataModule -- "utilizes" --> FeatureEngineering
+    InferenceDataModule -- "utilizes" --> FeatureEngineering
+    InferenceDataModule -- "utilizes" --> DataTokenization
+    InferenceDataModule -- "utilizes" --> DataCropping
+    DataParsing -- "parses data into" --> DataManifestAndTypes
+    DataWriting -- "writes data from" --> DataManifestAndTypes
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Data Management & Augmentation component handles the loading, batching, sampling, and cropping of prepared data for training, validation, and inference. It incorporates various sampling strategies (cluster, random, distillation) and mechanisms to filter and augment data subsets, ensuring efficient processing for model training and inference.
+
+### DataSampling
+This component is responsible for implementing various sampling approaches for chains and interfaces from a dataset. It includes strategies like weighted sampling based on cluster IDs and molecular types (protein, nucleic acid, ligand), random sampling, and distillation sampling.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/cluster.py#L163-L283" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.cluster.ClusterSampler` (163:283)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/cluster.py#L108-L160" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.cluster.get_interface_weight` (108:160)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/cluster.py#L11-L27" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.cluster.get_chain_cluster` (11:27)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/cluster.py#L30-L55" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.cluster.get_interface_cluster` (30:55)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/cluster.py#L58-L105" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.cluster.get_chain_weight` (58:105)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/sampler.py#L29-L49" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.sampler.Sampler` (29:49)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/random.py#L10-L39" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.random.RandomSampler` (10:39)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/distillation.py#L9-L57" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.distillation.DistillationSampler` (9:57)</a>
+
+
+### DataCropping
+This component handles the selective extraction or 'cropping' of specific chain or interface tokens from data records, often involving random selection mechanisms. It includes specialized croppers like `BoltzCropper` and `AffinityCropper`.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/boltz.py#L127-L296" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.crop.boltz.BoltzCropper` (127:296)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/boltz.py#L34-L65" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.crop.boltz.pick_chain_token` (34:65)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/boltz.py#L68-L124" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.crop.boltz.pick_interface_token` (68:124)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/boltz.py#L12-L31" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.crop.boltz.pick_random_token` (12:31)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/cropper.py#L9-L45" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.crop.cropper.Cropper` (9:45)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/affinity.py#L11-L164" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.crop.affinity.AffinityCropper` (11:164)</a>
+
+
+### DataFiltering
+This component provides mechanisms to filter data based on specific criteria, such as identifying and excluding records with clashing polymer chains, or filtering based on date, max residues, resolution, size, or subsets.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L175-L299" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.static.polymer.ClashingChainsFilter` (175:299)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L166-L172" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.static.polymer.Clash` (166:172)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/filter.py#L8-L26" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.static.filter.StaticFilter` (8:26)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/filter.py#L6-L24" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.dynamic.filter.DynamicFilter` (6:24)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/date.py#L8-L76" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.dynamic.date.DateFilter` (8:76)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/max_residues.py#L5-L37" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.dynamic.max_residues.MaxResiduesFilter` (5:37)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/resolution.py#L5-L34" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.dynamic.resolution.ResolutionFilter` (5:34)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/size.py#L5-L38" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.dynamic.size.SizeFilter` (5:38)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/dynamic/subset.py#L7-L42" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.dynamic.subset.SubsetFilter` (7:42)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/ligand.py#L8-L37" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.static.ligand.ExcludedLigands` (8:37)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L104-L162" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.static.polymer.ConsecutiveCA` (104:162)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L12-L62" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.static.polymer.MinimumLengthFilter` (12:62)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L65-L101" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.static.polymer.UnknownFilter` (65:101)</a>
+
+
+### DataManifestAndTypes
+This component defines the fundamental data structures and types used throughout the `boltz` system, including the `Manifest` class for loading and managing dataset metadata, and other core data types like `Record`, `Structure`, and `MSA`.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L647-L683" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.Manifest` (647:683)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L566-L576" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.Record` (566:576)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L169-L319" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.Structure` (169:319)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L469-L474" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.MSA` (469:474)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L323-L441" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.StructureV2` (323:441)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L483-L494" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.StructureInfo` (483:494)</a>
+
+
+### TrainingDataModule
+This component orchestrates the entire data pipeline for model training, including loading manifests, applying feature transformations like symmetry, and preparing various datasets (training, validation) for consumption by a machine learning framework. It utilizes various data processing components like croppers, featurizers, filters, samplers, and tokenizers.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L491-L684" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.training.BoltzTrainingDataModule` (491:684)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L71-L81" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.training.Dataset` (71:81)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L186-L335" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.training.TrainingDataset` (186:335)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L338-L488" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.training.ValidationDataset` (338:488)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L36-L67" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.training.DataConfig` (36:67)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L467-L660" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.trainingv2.BoltzTrainingDataModule` (467:660)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L71-L81" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.trainingv2.Dataset` (71:81)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L168-L314" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.trainingv2.TrainingDataset` (168:314)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L317-L464" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.trainingv2.ValidationDataset` (317:464)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/trainingv2.py#L36-L67" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.trainingv2.DataConfig` (36:67)</a>
+
+
+### InferenceDataModule
+This component is dedicated to preparing data specifically for model inference, providing prediction datasets and dataloaders. It leverages featurizers and tokenizers to process data for inference.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L223-L307" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inference.BoltzInferenceDataModule` (223:307)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L121-L220" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inference.PredictionDataset` (121:220)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L249-L271" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inference.BoltzInferenceDataModule:predict_dataloader` (249:271)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L313-L429" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inferencev2.Boltz2InferenceDataModule` (313:429)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L157-L310" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inferencev2.PredictionDataset` (157:310)</a>
+
+
+### FeatureEngineering
+This component is responsible for generating and converting various features from atomic and molecular data, including symmetry-related features, which are crucial for downstream tasks like model training and inference. It includes different featurizer implementations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/symmetry.py#L35-L67" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.symmetry.get_symmetries` (35:67)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/symmetry.py#L15-L32" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.symmetry.convert_atom_name` (15:32)</a>
+- `boltz.src.boltz.data.feature.featurizer.BoltzFeaturizer` (full file reference)
+- `boltz.src.boltz.data.feature.featurizerv2.Boltz2Featurizer` (full file reference)
+
+
+### DataTokenization
+This component handles the tokenization of data, converting raw data into a format suitable for model input. It includes different tokenizer implementations like `BoltzTokenizer` and `Boltz2Tokenizer`.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz.py#L32-L195" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz.BoltzTokenizer` (32:195)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L349-L396" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz2.Boltz2Tokenizer` (349:396)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/tokenizer.py#L6-L24" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.tokenizer.Tokenizer` (6:24)</a>
+
+
+### DataParsing
+This component is responsible for parsing various data formats, such as A3M, CSV, FASTA, MMCIF, and YAML, into the internal data structures used by the `boltz` system.
+
+
+**Related Classes/Methods**:
+
+- `boltz.src.boltz.data.parse.a3m` (full file reference)
+- `boltz.src.boltz.data.parse.csv` (full file reference)
+- `boltz.src.boltz.data.parse.fasta` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints` (full file reference)
+- `boltz.src.boltz.data.parse.schema` (full file reference)
+- `boltz.src.boltz.data.parse.yaml` (full file reference)
+
+
+### DataWriting
+This component provides functionalities for writing processed data into various output formats, such as MMCIF and PDB.
+
+
+**Related Classes/Methods**:
+
+- `boltz.src.boltz.data.write.mmcif` (full file reference)
+- `boltz.src.boltz.data.write.pdb` (full file reference)
+- `boltz.src.boltz.data.write.writer.Writer` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data Processing & Feature Engineering.md
+++ b/.codeboarding/Data Processing & Feature Engineering.md
@@ -1,0 +1,175 @@
+```mermaid
+graph LR
+    Input_Parsing["Input Parsing"]
+    MSA_Generation["MSA Generation"]
+    Data_Models["Data Models"]
+    Feature_Engineering["Feature Engineering"]
+    Tokenization["Tokenization"]
+    Inference_Data_Module["Inference Data Module"]
+    Output_Evaluation["Output & Evaluation"]
+    Input_Parsing -- "initiates MSA computation" --> MSA_Generation
+    Input_Parsing -- "generates structured data" --> Data_Models
+    MSA_Generation -- "produces MSA data" --> Data_Models
+    Data_Models -- "provides data for processing" --> Feature_Engineering
+    Data_Models -- "provides data for processing" --> Tokenization
+    Feature_Engineering -- "transforms into features" --> Data_Models
+    Tokenization -- "produces tokenized data" --> Data_Models
+    Inference_Data_Module -- "loads and prepares input" --> Input_Parsing
+    Inference_Data_Module -- "requests feature generation" --> Feature_Engineering
+    Inference_Data_Module -- "requests tokenization" --> Tokenization
+    Inference_Data_Module -- "utilizes data models" --> Data_Models
+    Output_Evaluation -- "utilizes parsed structures" --> Data_Models
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The "Data Processing & Feature Engineering" subsystem is responsible for transforming raw biological input data from various formats into structured, featurized, and tokenized representations suitable for machine learning models. It encompasses the initial parsing of diverse data types, generation of multiple sequence alignments, definition of core data structures, extraction of numerical features, and conversion into tokenized sequences, culminating in data preparation for model inference and subsequent output handling.
+
+### Input Parsing
+Manages the parsing of raw input data from various formats (MMCIF, FASTA, YAML, CSV, A3M) into internal data structures. This component is responsible for the initial ingestion and structuring of diverse biological data, including the extraction of detailed structural information and computation of geometric and chemical constraints.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L477-L605" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:process_input` (477:605)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L404-L474" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:compute_msa` (404:474)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/fasta.py#L11-L138" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.fasta:parse_fasta` (11:138)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/yaml.py#L10-L68" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.yaml:parse_yaml` (10:68)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/a3m.py#L104-L134" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.a3m:parse_a3m` (104:134)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/csv.py#L11-L100" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.csv:parse_csv` (11:100)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/mmcif_with_constraints.py#L200-L300" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.mmcif_with_constraints:parse_mmcif` (200:300)</a>
+- `boltz.src.boltz.data.parse.mmcif_with_constraints:compute_geometry_constraints` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints:compute_chiral_atom_constraints` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints:compute_stereo_bond_constraints` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints:compute_flatness_constraints` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedRDKitBoundsConstraint` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedChiralAtomConstraint` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedStereoBondConstraint` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedPlanarBondConstraint` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedPlanarRing5Constraint` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedPlanarRing6Constraint` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedAtom` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedResidue` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedBond` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedChain` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.get_mol` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.get_dates` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.get_resolution` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.get_method` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.get_experiment_conditions` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.compute_covalent_ligands` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.parse_connection` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.compute_interfaces` (full file reference)
+- `boltz.src.boltz.data.parse.mmcif_with_constraints.ParsedStructure` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/schema.py#L932-L1000" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.schema:parse_boltz_schema` (932:1000)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/schema.py#L788-L916" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.schema.parse_polymer` (788:916)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/schema.py#L635-L785" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.schema.parse_ccd_residue` (635:785)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/schema.py#L151-L160" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.schema.ParsedChain` (151:160)</a>
+- `boltz.src.boltz.data.parse.schema.standardize` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/schema.py#L198-L252" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.schema.compute_3d_conformer` (198:252)</a>
+- `boltz.data.parse.mmcif.parse_mmcif` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/schema.py#L588-L615" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.schema.get_template_records_from_matching` (588:615)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/schema.py#L541-L585" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.schema.get_template_records_from_search` (541:585)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/schema.py#L178-L195" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.schema.convert_atom_name` (178:195)</a>
+
+
+### MSA Generation
+Manages the execution and retrieval of Multiple Sequence Alignments using MMseqs2, a critical step for providing evolutionary context to protein structures.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/msa/mmseqs2.py#L20-L254" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.msa.mmseqs2:run_mmseqs2` (20:254)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/msa/mmseqs2.py#L35-L72" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.msa.mmseqs2.run_mmseqs2.submit` (35:72)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/msa/mmseqs2.py#L74-L102" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.msa.mmseqs2.run_mmseqs2.status` (74:102)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/msa/mmseqs2.py#L104-L128" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.msa.mmseqs2.run_mmseqs2.download` (104:128)</a>
+
+
+### Data Models
+Defines the core data structures and types used across the Boltz system, representing biological entities like structures, MSAs, and various associated information and constraints. It acts as the central repository for structured data.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L169-L319" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.Structure` (169:319)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L181-L204" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.Structure:load` (181:204)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L206-L319" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.Structure:remove_invalid_chains` (206:319)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L323-L441" target="_blank" rel="noopener noreferrer">`boltz.data.types.StructureV2` (323:441)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L765-L777" target="_blank" rel="noopener noreferrer">`boltz.data.types.Tokenized` (765:777)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L469-L474" target="_blank" rel="noopener noreferrer">`boltz.data.types.MSA` (469:474)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L618-L626" target="_blank" rel="noopener noreferrer">`boltz.data.types.ResidueConstraints` (618:626)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L483-L494" target="_blank" rel="noopener noreferrer">`boltz.data.types.StructureInfo` (483:494)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L558-L562" target="_blank" rel="noopener noreferrer">`boltz.data.types.AffinityInfo` (558:562)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L498-L508" target="_blank" rel="noopener noreferrer">`boltz.data.types.ChainInfo` (498:508)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L521-L524" target="_blank" rel="noopener noreferrer">`boltz.data.types.InferenceOptions` (521:524)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L566-L576" target="_blank" rel="noopener noreferrer">`boltz.data.types.Record` (566:576)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L635-L643" target="_blank" rel="noopener noreferrer">`boltz.data.types.Target` (635:643)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz.py#L11-L29" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz.TokenData` (11:29)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L19-L43" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz2.TokenData` (19:43)</a>
+
+
+### Feature Engineering
+Transforms raw biological data and parsed structures into numerical features for machine learning models, handling different versions of featurization logic including token, atom, MSA, template, and symmetry features.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/featurizer.py#L100-L200" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.featurizer.BoltzFeaturizer:process` (100:200)</a>
+- `boltz.src.boltz.data.feature.featurizerv2.Boltz2Featurizer:process` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/featurizer.py#L488-L670" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.featurizer.process_token_features` (488:670)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/featurizer.py#L673-L896" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.featurizer.process_atom_features` (673:896)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/featurizer.py#L899-L971" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.featurizer.process_msa_features` (899:971)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/featurizer.py#L974-L994" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.featurizer.process_symmetry_features` (974:994)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/featurizer.py#L997-L1000" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.featurizer.process_residue_constraint_features` (997:1000)</a>
+- `boltz.src.boltz.data.feature.featurizer.process_chain_feature_constraints` (full file reference)
+- `boltz.src.boltz.data.feature.featurizerv2.process_ensemble_features` (full file reference)
+- `boltz.src.boltz.data.feature.featurizerv2.process_template_features` (full file reference)
+- `boltz.src.boltz.data.feature.featurizerv2.load_dummy_templates_features` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/mol.py#L84-L193" target="_blank" rel="noopener noreferrer">`boltz.data.mol.get_symmetries` (84:193)</a>
+
+
+### Tokenization
+Converts processed biological data into a tokenized format, essential for sequence-based model inputs, by mapping structural and sequence information to discrete tokens.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz.py#L35-L195" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz.BoltzTokenizer:tokenize` (35:195)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L349-L396" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz2.Boltz2Tokenizer` (349:396)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L352-L396" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz2.Boltz2Tokenizer:tokenize` (352:396)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L104-L346" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz2:tokenize_structure` (104:346)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L46-L76" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz2.compute_frame` (46:76)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L79-L101" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz2.get_unk_token` (79:101)</a>
+
+
+### Inference Data Module
+Prepares and manages datasets and dataloaders specifically for model inference, integrating data loading, tokenization, and featurization to provide a streamlined data pipeline for models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L151-L209" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inference.PredictionDataset:__getitem__` (151:209)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L249-L271" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inference.BoltzInferenceDataModule:predict_dataloader` (249:271)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L160-L204" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inferencev2.PredictionDataset:__init__` (160:204)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L206-L299" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inferencev2.PredictionDataset:__getitem__` (206:299)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L25-L74" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inference.load_input` (25:74)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inferencev2.py#L27-L109" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inferencev2.load_input` (27:109)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L84-L140" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.training:load_input` (84:140)</a>
+
+
+### Output & Evaluation
+Handles the writing of results in various formats (e.g., MMCIF, PDB) and provides functions for evaluating physical simulation metrics, ensuring that model outputs can be stored and assessed.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/writer.py#L47-L245" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.write.writer.BoltzWriter:write_on_batch_end` (47:245)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/scripts/eval/physcialsim_metrics.py#L210-L238" target="_blank" rel="noopener noreferrer">`boltz.scripts.eval.physcialsim_metrics:process_fn` (210:238)</a>
+- `boltz.data.write.mmcif` (full file reference)
+- `boltz.data.write.pdb` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/General Utilities.md
+++ b/.codeboarding/General Utilities.md
@@ -1,0 +1,63 @@
+```mermaid
+graph LR
+    Core_Utilities["Core Utilities"]
+    Geometric_Transformations["Geometric Transformations"]
+    Data_Augmentation_Pipeline["Data Augmentation Pipeline"]
+    EMA_Management["EMA Management"]
+    Data_Augmentation_Pipeline -- "relies on" --> Geometric_Transformations
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph outlines the key components within the `boltz.src.boltz.model.modules.utils` module, focusing on their structure, functionality, and interdependencies. The module provides a range of utility functions, from basic existence checks and default value assignments to complex geometric transformations and data augmentation pipelines, all crucial for the project's machine learning models. The main flow involves preparing and transforming data, managing model parameters, and applying various mathematical operations.
+
+### Core Utilities
+Provides fundamental utility functions like existence checks, default value assignment, logarithmic operations, and a specialized activation function (SwiGLU). It also includes a linear layer without bias.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L14-L14" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:LinearNoBias` (14:14)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L17-L18" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:exists` (17:18)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L21-L22" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:default` (21:22)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L25-L26" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:log` (25:26)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L29-L35" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:SwiGLU` (29:35)</a>
+
+
+### Geometric Transformations
+Handles all aspects of 3D geometric transformations, including quaternion manipulation, conversion to rotation matrices, generation of random quaternions and rotation matrices, and basic coordinate centering.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L213-L228" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:_copysign` (213:228)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L231-L260" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:quaternion_to_matrix` (231:260)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L263-L284" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:random_quaternions` (263:284)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L287-L303" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:random_rotations` (287:303)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L38-L43" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:center` (38:43)</a>
+
+
+### Data Augmentation Pipeline
+Orchestrates the application of random augmentations (rotations and translations) and centering to input coordinate data, often used in machine learning pipelines for data variability.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L46-L53" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:compute_random_augmentation` (46:53)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L56-L64" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:randomly_rotate` (56:64)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L67-L100" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:center_random_augmentation` (67:100)</a>
+
+
+### EMA Management
+Manages the exponential moving average of model parameters, providing functionalities to update, store, restore, and copy parameters for stable training and evaluation.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L103-L207" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:ExponentialMovingAverage` (103:207)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Neural Network Architecture.md
+++ b/.codeboarding/Neural Network Architecture.md
@@ -1,0 +1,196 @@
+```mermaid
+graph LR
+    Boltz_Models["Boltz Models"]
+    Diffusion_System["Diffusion System"]
+    Confidence_Prediction["Confidence Prediction"]
+    Trunk_Architecture["Trunk Architecture"]
+    Encoder_Modules["Encoder Modules"]
+    Core_Layers["Core Layers"]
+    Initialization_Utilities["Initialization & Utilities"]
+    Potential_Loss_Functions["Potential & Loss Functions"]
+    Affinity_Module["Affinity Module"]
+    Diffusion_Conditioning["Diffusion Conditioning"]
+    Neural_Network_Architecture["Neural Network Architecture"]
+    Boltz_Models -- "orchestrates" --> Neural_Network_Architecture
+    Boltz_Models -- "integrates" --> Confidence_Prediction
+    Boltz_Models -- "integrates" --> Affinity_Module
+    Neural_Network_Architecture -- "comprises" --> Trunk_Architecture
+    Neural_Network_Architecture -- "comprises" --> Encoder_Modules
+    Neural_Network_Architecture -- "comprises" --> Core_Layers
+    Neural_Network_Architecture -- "provides transformer blocks for" --> Diffusion_System
+    Trunk_Architecture -- "processes data with" --> Core_Layers
+    Trunk_Architecture -- "receives input from" --> Encoder_Modules
+    Diffusion_System -- "utilizes" --> Potential_Loss_Functions
+    Diffusion_System -- "processes input from" --> Encoder_Modules
+    Diffusion_System -- "transforms data using" --> Core_Layers
+    Confidence_Prediction -- "analyzes output from" --> Trunk_Architecture
+    Confidence_Prediction -- "processes input from" --> Encoder_Modules
+    Diffusion_Conditioning -- "provides input to" --> Diffusion_System
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This architectural overview details the core components of the Boltz system, designed for protein structure prediction and diffusion. It highlights the main Boltz models as orchestrators, the foundational Neural Network Architecture providing core computational blocks, and specialized modules for diffusion, confidence prediction, and feature encoding. The graph illustrates the flow of data and dependencies among these components, showcasing how fundamental layers and utilities support the complex tasks of molecular modeling.
+
+### Boltz Models
+These are the main entry points of the Boltz system, orchestrating the entire protein structure prediction or diffusion process. They integrate various sub-modules like embedding, MSA processing, pairformer blocks, diffusion models, and confidence prediction. Boltz1 and Boltz2 represent different versions or configurations of the overall model.
+
+
+**Related Classes/Methods**:
+
+- `boltz.src.boltz.model.models.boltz1.Boltz1` (full file reference)
+- `boltz.src.boltz.model.models.boltz2.Boltz2` (full file reference)
+
+
+### Diffusion System
+This component is responsible for the diffusion-based generation or refinement of molecular structures. It typically involves a DiffusionModule that processes input features and a DiffusionTransformer that applies a series of transformations to refine the diffused coordinates. AtomDiffusion acts as the main interface for the diffusion process, handling sampling and forward passes.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusion.py#L41-L229" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusion.DiffusionModule` (41:229)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusion.py#L284-L844" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusion.AtomDiffusion` (284:844)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusionv2.py#L38-L176" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusionv2.DiffusionModule` (38:176)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusionv2.py#L179-L677" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusionv2.AtomDiffusion` (179:677)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformers.py#L90-L177" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformers.DiffusionTransformer` (90:177)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L68-L137" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.DiffusionTransformer` (68:137)</a>
+
+
+### Confidence Prediction
+This module assesses the quality and confidence of the predicted protein structures. It takes features from the main model and outputs metrics like pLDDT, pTM, and iPTM, which indicate the accuracy of the predicted coordinates and interfaces.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidence.py#L20-L334" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidence.ConfidenceModule` (20:334)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidence.py#L337-L481" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidence.ConfidenceHeads` (337:481)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidencev2.py#L19-L237" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidencev2.ConfidenceModule` (19:237)</a>
+
+
+### Trunk Architecture
+This forms the core of the feature processing pipeline, handling the main transformations of sequence and pair representations. It includes modules for embedding initial inputs, processing Multiple Sequence Alignments (MSA), and applying pair-wise transformations through Pairformer blocks. It also includes modules for distogram, B-factor, and contact conditioning.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L24-L113" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.InputEmbedder` (24:113)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L116-L289" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.MSAModule` (116:289)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L424-L549" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.PairformerModule` (424:549)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L68-L208" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.InputEmbedder` (68:208)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L512-L669" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.MSAModule` (512:669)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L21-L65" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.ContactConditioning` (21:65)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L361-L509" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.TemplateV2Module` (361:509)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L211-L358" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.TemplateModule` (211:358)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L794-L828" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.DistogramModule` (794:828)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L761-L791" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.BFactorModule` (761:791)</a>
+
+
+### Encoder Modules
+These modules are responsible for encoding various input features, such as atom-level information, relative positional embeddings, and conditioning signals. They prepare the data for further processing by the main trunk and diffusion models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L288-L540" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.AtomAttentionEncoder` (288:540)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L45-L133" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.RelativePositionEncoder` (45:133)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L136-L206" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.SingleConditioning` (136:206)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L209-L260" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.PairwiseConditioning` (209:260)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L543-L639" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.AtomAttentionDecoder` (543:639)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L123-L177" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.SingleConditioning` (123:177)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L414-L492" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.AtomAttentionEncoder` (414:492)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L245-L411" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.AtomEncoder` (245:411)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encodersv2.py#L495-L565" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encodersv2.AtomAttentionDecoder` (495:565)</a>
+
+
+### Core Layers
+This component encompasses the fundamental building blocks of the neural network architecture. These layers perform specific transformations like attention mechanisms (Pairformer, Triangular Attention), triangular multiplications, transitions, dropout, and normalization, which are reused across different modules of the model.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/pairformer.py#L21-L107" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.pairformer.PairformerLayer` (21:107)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/pairformer.py#L198-L257" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.pairformer.PairformerNoSeqLayer` (198:257)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L292-L421" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.MSALayer` (292:421)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L552-L648" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.PairformerLayer` (552:648)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunkv2.py#L672-L758" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunkv2.MSALayer` (672:758)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/attentionv2.py#L10-L111" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.attentionv2.AttentionPairBias` (10:111)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/attention.py#L8-L132" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.attention.AttentionPairBias` (8:132)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_mult.py#L7-L74" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_mult.TriangleMultiplicationOutgoing` (7:74)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_mult.py#L77-L144" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_mult.TriangleMultiplicationIncoming` (77:144)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/attention.py#L33-L162" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.attention.TriangleAttention` (33:162)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/attention.py#L169-L172" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.attention.TriangleAttentionEndingNode` (169:172)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/transition.py#L8-L78" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.transition.Transition` (8:78)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/dropout.py#L5-L34" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.dropout.get_dropout_mask` (5:34)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/pair_averaging.py#L7-L135" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.pair_averaging.PairWeightedAveraging` (7:135)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/outer_product_mean.py#L7-L98" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.outer_product_mean.OuterProductMean` (7:98)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/primitives.py#L148-L181" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.primitives.LayerNorm` (148:181)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/primitives.py#L52-L145" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.primitives.Linear` (52:145)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/primitives.py#L305-L520" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.primitives.Attention` (305:520)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L17-L31" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.AdaLN` (17:31)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L34-L65" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.ConditionedTransitionBlock` (34:65)</a>
+
+
+### Initialization & Utilities
+This component provides helper functions for initializing model parameters, applying dropout masks, and performing common utility operations like default value handling, random augmentation, and tensor permutations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L73-L75" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize.final_init_` (73:75)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/initialize.py#L78-L80" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.initialize.gating_init_` (78:80)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L21-L22" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils.default` (21:22)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L46-L53" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils.compute_random_augmentation` (46:53)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L67-L100" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils.center_random_augmentation` (67:100)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/utils.py#L258-L380" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.utils.chunk_layer` (258:380)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/utils.py#L32-L35" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.utils.permute_final_dims` (32:35)</a>
+
+
+### Potential & Loss Functions
+This component defines potential energy functions used in the diffusion process and loss functions for training the model. These are crucial for guiding the model towards physically plausible and accurate protein structures.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L417-L482" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.get_potentials` (417:482)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L89-L98" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.Potential.compute_parameters` (89:98)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L24-L45" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.Potential.compute` (24:45)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L47-L87" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials.Potential.compute_gradient` (47:87)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/diffusionv2.py#L9-L79" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.diffusionv2.weighted_rigid_align` (9:79)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/diffusion.py#L8-L94" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.diffusion.weighted_rigid_align` (8:94)</a>
+
+
+### Affinity Module
+This module is likely involved in predicting or refining interaction affinities, possibly for protein-ligand or protein-protein binding.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/affinity.py#L34-L135" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.affinity.AffinityModule` (34:135)</a>
+
+
+### Diffusion Conditioning
+This module provides conditioning signals to the diffusion process, guiding the generation of structures based on specific inputs or constraints.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusion_conditioning.py#L13-L116" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusion_conditioning.DiffusionConditioning` (13:116)</a>
+
+
+### Neural Network Architecture
+This component represents the overarching design and collection of fundamental neural network building blocks that form the core computational engine of the Boltz models. It integrates modules for input embedding, Multiple Sequence Alignment (MSA) processing, pairwise transformations, various encoders (single, pairwise, atom attention), transformer blocks, and core neural network layers like attention mechanisms and triangular multiplications. It serves as the comprehensive architectural foundation upon which the entire Boltz system operates.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L24-L113" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.InputEmbedder` (24:113)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L116-L289" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.MSAModule` (116:289)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L288-L540" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.AtomAttentionEncoder` (288:540)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L68-L137" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.DiffusionTransformer` (68:137)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/attention.py#L33-L162" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.attention.TriangleAttention` (33:162)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Training & Evaluation Framework.md
+++ b/.codeboarding/Training & Evaluation Framework.md
@@ -1,0 +1,158 @@
+```mermaid
+graph LR
+    Training_Orchestration["Training Orchestration"]
+    Evaluation_Metrics["Evaluation & Metrics"]
+    Boltz_Models["Boltz Models"]
+    Data_Modules["Data Modules"]
+    Loss_Functions["Loss Functions"]
+    Diffusion_Confidence_Modules["Diffusion & Confidence Modules"]
+    Data_Writing_Output["Data Writing & Output"]
+    Optimization_Callbacks["Optimization & Callbacks"]
+    Molecular_Data_Processing["Molecular Data Processing"]
+    Model_Potentials["Model Potentials"]
+    Training_Orchestration -- "Trains" --> Boltz_Models
+    Training_Orchestration -- "Manages data for" --> Data_Modules
+    Training_Orchestration -- "Applies optimization strategies and callbacks to" --> Optimization_Callbacks
+    Boltz_Models -- "Minimizes" --> Loss_Functions
+    Boltz_Models -- "Utilizes" --> Diffusion_Confidence_Modules
+    Boltz_Models -- "Processes input/output data with" --> Molecular_Data_Processing
+    Boltz_Models -- "Incorporates" --> Model_Potentials
+    Data_Modules -- "Prepares data using" --> Molecular_Data_Processing
+    Data_Writing_Output -- "Serializes structures via" --> Molecular_Data_Processing
+    Evaluation_Metrics -- "Computes performance using" --> Loss_Functions
+    Loss_Functions -- "Depends on molecular data utilities for calculations" --> Molecular_Data_Processing
+    Diffusion_Confidence_Modules -- "Contributes to loss calculation" --> Loss_Functions
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Training & Evaluation Framework provides the essential infrastructure for developing and assessing Boltz models. It encompasses the definition of various loss functions, physical potential functions to guide molecular generation, and optimization utilities. The framework orchestrates the training process, manages data pipelines, handles the output of predicted structures, and evaluates model performance using a suite of metrics.
+
+### Training Orchestration
+This component is responsible for setting up and executing the training process for Boltz models. It handles configuration loading, model and data module instantiation, logger setup (e.g., Weights & Biases), checkpointing, and orchestrates the training and validation loops.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/scripts/train/train.py#L80-L235" target="_blank" rel="noopener noreferrer">`boltz.scripts.train.train:train` (80:235)</a>
+
+
+### Evaluation & Metrics
+This component focuses on aggregating and computing various evaluation metrics, such as AF3, CHAI, and Boltz-specific metrics, to assess the performance of trained models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/scripts/eval/aggregate_evals.py#L297-L505" target="_blank" rel="noopener noreferrer">`boltz.scripts.eval.aggregate_evals:eval_models` (297:505)</a>
+
+
+### Boltz Models
+This component encompasses the core neural network architectures, Boltz1 and Boltz2, which are responsible for predicting protein structures. They define the training, validation, and prediction steps, integrating various sub-modules and loss functions.
+
+
+**Related Classes/Methods**:
+
+- `boltz.src.boltz.model.models.boltz1.Boltz1` (full file reference)
+- `boltz.src.boltz.model.models.boltz2.Boltz2` (full file reference)
+
+
+### Data Modules
+This component manages the entire data pipeline, including loading raw input data (structures, MSAs), tokenization, featurization, padding, and creating datasets and dataloaders for both training and inference.
+
+
+**Related Classes/Methods**:
+
+- `boltz.src.boltz.data.module.training` (full file reference)
+- `boltz.src.boltz.data.module.inference` (full file reference)
+- `boltz.src.boltz.data.module.inferencev2` (full file reference)
+
+
+### Loss Functions
+This component provides a collection of loss functions crucial for training the Boltz models. These include losses related to confidence (pLDDT, pAE), diffusion, distograms, and b-factors, guiding the model's learning process.
+
+
+**Related Classes/Methods**:
+
+- `boltz.src.boltz.model.loss.validation` (full file reference)
+- `boltz.src.boltz.model.loss.confidence` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidencev2.py#L8-L87" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidencev2:confidence_loss` (8:87)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/distogram.py#L5-L48" target="_blank" rel="noopener noreferrer">`boltz.model.loss.distogram.distogram_loss` (5:48)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/distogramv2.py#L5-L105" target="_blank" rel="noopener noreferrer">`boltz.model.loss.distogramv2.distogram_loss` (5:105)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/bfactor.py#L5-L49" target="_blank" rel="noopener noreferrer">`boltz.model.loss.bfactor.bfactor_loss_fn` (5:49)</a>
+
+
+### Diffusion & Confidence Modules
+This component contains the specific neural network modules responsible for implementing the atom diffusion process and predicting confidence metrics (like pLDDT and pAE) within the Boltz models.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusion.py#L284-L844" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusion.AtomDiffusion` (284:844)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusionv2.py#L179-L677" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusionv2.AtomDiffusion` (179:677)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidence.py#L337-L481" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidence.ConfidenceHeads` (337:481)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidencev2.py#L240-L503" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidencev2.ConfidenceHeads` (240:503)</a>
+- `boltz.src.boltz.model.layers.confidence_utils` (full file reference)
+- `boltz.model.modules.confidence_utils` (full file reference)
+
+
+### Data Writing & Output
+This component handles the serialization of predicted protein structures into standard bioinformatics formats such as PDB and mmCIF, facilitating downstream analysis and visualization.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/writer.py#L17-L254" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.write.writer.BoltzWriter` (17:254)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/mmcif.py#L17-L305" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.write.mmcif:to_mmcif` (17:305)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/pdb.py#L11-L171" target="_blank" rel="noopener noreferrer">`boltz.data.write.pdb.to_pdb` (11:171)</a>
+
+
+### Optimization & Callbacks
+This component provides utilities for optimizing model training, including learning rate schedulers (e.g., AlphaFoldLRScheduler) and callbacks like Exponential Moving Average (EMA) for improving model stability and performance.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/optim/ema.py#L14-L389" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.optim.ema.EMA` (14:389)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/optim/scheduler.py#L4-L99" target="_blank" rel="noopener noreferrer">`boltz.model.optim.scheduler.AlphaFoldLRScheduler` (4:99)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L103-L207" target="_blank" rel="noopener noreferrer">`boltz.model.modules.utils.ExponentialMovingAverage` (103:207)</a>
+
+
+### Molecular Data Processing
+This component offers a suite of utilities for manipulating and preparing molecular data. This includes tokenization of sequences, featurization of structural information, padding operations for batching, and handling symmetry-related transformations.
+
+
+**Related Classes/Methods**:
+
+- `boltz.src.boltz.data.mol` (full file reference)
+- `boltz.src.boltz.data.feature.symmetry` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/pad.py#L6-L32" target="_blank" rel="noopener noreferrer">`boltz.data.pad.pad_dim` (6:32)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz.py#L32-L195" target="_blank" rel="noopener noreferrer">`boltz.data.tokenize.boltz.BoltzTokenizer` (32:195)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz2.py#L349-L396" target="_blank" rel="noopener noreferrer">`boltz.data.tokenize.boltz2.Boltz2Tokenizer` (349:396)</a>
+- `boltz.data.feature.featurizer.BoltzFeaturizer` (full file reference)
+- `boltz.data.feature.featurizerv2.Boltz2Featurizer` (full file reference)
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/affinity.py#L11-L164" target="_blank" rel="noopener noreferrer">`boltz.data.crop.affinity.AffinityCropper` (11:164)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/mol.py#L42-L56" target="_blank" rel="noopener noreferrer">`boltz.data.mol.load_canonicals` (42:56)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/mol.py#L16-L39" target="_blank" rel="noopener noreferrer">`boltz.data.mol.load_molecules` (16:39)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L15-L44" target="_blank" rel="noopener noreferrer">`boltz.data.types.NumpySerializable` (15:44)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L169-L319" target="_blank" rel="noopener noreferrer">`boltz.data.types.Structure` (169:319)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L469-L474" target="_blank" rel="noopener noreferrer">`boltz.data.types.MSA` (469:474)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L692-L700" target="_blank" rel="noopener noreferrer">`boltz.data.types.Input` (692:700)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L323-L441" target="_blank" rel="noopener noreferrer">`boltz.data.types.StructureV2` (323:441)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L647-L683" target="_blank" rel="noopener noreferrer">`boltz.data.types.Manifest` (647:683)</a>
+
+
+### Model Potentials
+This component defines various potential functions that can be incorporated into the Boltz models, likely to enforce physical or chemical constraints during structure prediction, such as Van der Waals overlap or bond stereochemistry.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L417-L482" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials:get_potentials` (417:482)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/schedules.py#L8-L18" target="_blank" rel="noopener noreferrer">`boltz.model.potentials.schedules.ExponentialInterpolation` (8:18)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/schedules.py#L20-L32" target="_blank" rel="noopener noreferrer">`boltz.model.potentials.schedules.PiecewiseStepFunction` (20:32)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,128 @@
+```mermaid
+graph LR
+    Application_Orchestration["Application Orchestration"]
+    Boltz_Core_Models["Boltz Core Models"]
+    Neural_Network_Architecture["Neural Network Architecture"]
+    Data_Processing_Feature_Engineering["Data Processing & Feature Engineering"]
+    Data_Management_Augmentation["Data Management & Augmentation"]
+    Training_Evaluation_Framework["Training & Evaluation Framework"]
+    General_Utilities["General Utilities"]
+    Application_Orchestration -- "orchestrates" --> Boltz_Core_Models
+    Application_Orchestration -- "processes inputs using" --> Data_Processing_Feature_Engineering
+    Boltz_Core_Models -- "utilizes" --> Neural_Network_Architecture
+    Boltz_Core_Models -- "trained and evaluated by" --> Training_Evaluation_Framework
+    Boltz_Core_Models -- "consumes data from" --> Data_Management_Augmentation
+    Neural_Network_Architecture -- "provides building blocks for" --> Boltz_Core_Models
+    Neural_Network_Architecture -- "uses" --> General_Utilities
+    Data_Processing_Feature_Engineering -- "prepares data for" --> Data_Management_Augmentation
+    Data_Processing_Feature_Engineering -- "provides processed data to" --> Application_Orchestration
+    Data_Management_Augmentation -- "supplies data to" --> Boltz_Core_Models
+    Data_Management_Augmentation -- "receives data from" --> Data_Processing_Feature_Engineering
+    Training_Evaluation_Framework -- "optimizes and evaluates" --> Boltz_Core_Models
+    Training_Evaluation_Framework -- "uses data from" --> Data_Management_Augmentation
+    General_Utilities -- "supports" --> Neural_Network_Architecture
+    General_Utilities -- "supports" --> Data_Processing_Feature_Engineering
+    click Application_Orchestration href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/boltz/Application Orchestration.md" "Details"
+    click Boltz_Core_Models href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/boltz/Boltz Core Models.md" "Details"
+    click Neural_Network_Architecture href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/boltz/Neural Network Architecture.md" "Details"
+    click Data_Processing_Feature_Engineering href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/boltz/Data Processing & Feature Engineering.md" "Details"
+    click Data_Management_Augmentation href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/boltz/Data Management & Augmentation.md" "Details"
+    click Training_Evaluation_Framework href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/boltz/Training & Evaluation Framework.md" "Details"
+    click General_Utilities href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/boltz/General Utilities.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Boltz project is a molecular modeling framework primarily focused on predicting and generating molecular structures and their properties, such as binding affinity and confidence. The core functionality revolves around neural network models (Boltz1 and Boltz2) that leverage diffusion processes for structure generation. The system handles comprehensive data processing, from parsing raw molecular data and performing feature engineering to managing data loading and augmentation for efficient training. It includes a robust training and evaluation framework with various loss functions, physical potentials, and optimization utilities. The overall application workflow is orchestrated to manage the flow of data and execution across these specialized modules, with general utilities supporting various operations throughout the pipeline.
+
+### Application Orchestration
+Serves as the central control unit for the Boltz application, managing the overall workflow from input processing to model prediction. It coordinates data flow and execution across different modules.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L311-L352" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:filter_inputs_structure` (311:352)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L477-L605" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:process_input` (477:605)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/main.py#L933-L999" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.main:predict` (933:999)</a>
+
+
+### Boltz Core Models
+Encapsulates the primary Boltz neural network architectures (Boltz1, Boltz2), including their forward passes, training, validation, and prediction steps. It integrates diffusion, confidence, and affinity prediction capabilities.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/models/boltz2.py#L16-L300" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.models.boltz2.Boltz2` (16:300)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/models/boltz1.py#L16-L300" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.models.boltz1.Boltz1` (16:300)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/diffusionv2.py#L179-L677" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.diffusionv2.AtomDiffusion` (179:677)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/confidencev2.py#L19-L237" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.confidencev2.ConfidenceModule` (19:237)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/affinity.py#L34-L135" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.affinity.AffinityModule` (34:135)</a>
+
+
+### Neural Network Architecture
+Provides the fundamental building blocks for the Boltz models, including input embedding, MSA and pairformer modules, various encoders (single, pairwise, atom attention), transformer blocks, and core neural network layers like attention mechanisms and triangular multiplications.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L24-L113" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.InputEmbedder` (24:113)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/trunk.py#L116-L289" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.trunk.MSAModule` (116:289)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/encoders.py#L288-L540" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.encoders.AtomAttentionEncoder` (288:540)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/transformersv2.py#L68-L137" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.transformersv2.DiffusionTransformer` (68:137)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/layers/triangular_attention/attention.py#L33-L162" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.layers.triangular_attention.attention.TriangleAttention` (33:162)</a>
+
+
+### Data Processing & Feature Engineering
+Manages the parsing of raw input data (MMCIF, FASTA, YAML, CSV, A3M) into internal data structures, followed by comprehensive featurization and tokenization processes. This includes generating token, atom, MSA, template, and symmetry features, and handling molecular geometry and constraints.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/types.py#L169-L319" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.types.Structure` (169:319)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/parse/mmcif_with_constraints.py#L200-L300" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.parse.mmcif_with_constraints:parse_mmcif` (200:300)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/feature/featurizer.py#L100-L200" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.feature.featurizer.BoltzFeaturizer:process` (100:200)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/tokenize/boltz.py#L35-L195" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.tokenize.boltz.BoltzTokenizer:tokenize` (35:195)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/msa/mmseqs2.py#L20-L254" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.msa.mmseqs2:run_mmseqs2` (20:254)</a>
+
+
+### Data Management & Augmentation
+Handles the loading, batching, sampling, and cropping of prepared data for training, validation, and inference. It includes various sampling strategies (cluster, random, distillation) and mechanisms to filter and augment data subsets for efficient model processing.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/training.py#L491-L684" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.training.BoltzTrainingDataModule` (491:684)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/module/inference.py#L249-L271" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.module.inference.BoltzInferenceDataModule:predict_dataloader` (249:271)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/sample/cluster.py#L204-L283" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.sample.cluster.ClusterSampler:sample` (204:283)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/crop/boltz.py#L150-L296" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.crop.boltz.BoltzCropper:crop` (150:296)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/filter/static/polymer.py#L202-L299" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.filter.static.polymer.ClashingChainsFilter:filter` (202:299)</a>
+
+
+### Training & Evaluation Framework
+Provides the infrastructure for training Boltz models, including defining various loss functions (confidence, diffusion, validation metrics), physical potential functions to guide molecular generation, and optimization utilities like learning rate schedulers and Exponential Moving Average (EMA). It also handles outputting predicted structures and evaluating model performance.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/loss/confidencev2.py#L8-L87" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.loss.confidencev2:confidence_loss` (8:87)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/potentials/potentials.py#L417-L482" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.potentials.potentials:get_potentials` (417:482)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/optim/ema.py#L14-L389" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.optim.ema.EMA` (14:389)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/scripts/train/train.py#L80-L235" target="_blank" rel="noopener noreferrer">`boltz.scripts.train.train:train` (80:235)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/data/write/mmcif.py#L17-L305" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.data.write.mmcif:to_mmcif` (17:305)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/scripts/eval/aggregate_evals.py#L297-L505" target="_blank" rel="noopener noreferrer">`boltz.scripts.eval.aggregate_evals:eval_models` (297:505)</a>
+
+
+### General Utilities
+A collection of miscellaneous utility functions supporting various operations across the project, such as default value handling, random augmentations (rotations, quaternions), and centering operations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L21-L22" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:default` (21:22)</a>
+- <a href="https://github.com/jwohlwend/boltz/blob/master/src/boltz/model/modules/utils.py#L56-L64" target="_blank" rel="noopener noreferrer">`boltz.src.boltz.model.modules.utils:randomly_rotate` (56:64)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
Hey all, I would usually open a discussion first. But in this case they don't seem to be enabled for this repository.

In this PR, I have generated high-level diagrams for the boltz repository. You can see how they render here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/boltz/on_boarding.md

Me and a friend want to help people get up-to-speed with new codebases and believe that the best way is through visuals. That is why we generate diagram first documentation with the help of static analysis and LLMs. I would love to hear your opinion on the matter.

I think that our docs can be a nice addition to the ones you have in /docs. As I believe ours serve different purpose - to help new contributors get to know the codebase!

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.