### PR TITLE
Skipping targets when affinity option is not set.

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -376,6 +376,9 @@ def filter_inputs_affinity(
     """
     click.echo("Checking input data for affinity.")
 
+    # Get targets with affinity set
+    manifest = Manifest([r for r in manifest.records if r.affinity])
+    
     # Get all affinity targets
     existing = {
         r.id


### PR DESCRIPTION
When the affinity options are mixed in different records, (some targets are off, some targets are on), the Boltz tried calculate all affinities with them, causing the pre_affinity_xxx.npz not found errors.

I added a filter in the `filter_inputs_affinity` function to filter the records without r.affinity to avoid them calculated.