### PR TITLE
Fixes for training and Torch compatibility

### DIFF
--- a/src/boltz/model/layers/pairformer.py
+++ b/src/boltz/model/layers/pairformer.py
@@ -194,11 +194,11 @@ class PairformerModule(nn.Module):
                     mask,
                     pair_mask,
                     chunk_size_tri_attn,
-                    use_kernels=use_kernels,
+                    use_kernels,
                 )
             else:
                 s, z = layer(
-                    s, z, mask, pair_mask, chunk_size_tri_attn, use_kernels=use_kernels
+                    s, z, mask, pair_mask, chunk_size_tri_attn, use_kernels
                 )
         return s, z
 

--- a/src/boltz/model/modules/diffusion.py
+++ b/src/boltz/model/modules/diffusion.py
@@ -736,7 +736,7 @@ class AtomDiffusion(Module):
         noise = torch.randn_like(atom_coords)
         noised_atom_coords = atom_coords + padded_sigmas * noise
 
-        denoised_atom_coords, _ = self.preconditioned_network_forward(
+        denoised_atom_coords = self.preconditioned_network_forward(
             noised_atom_coords,
             sigmas,
             training=True,

--- a/src/boltz/model/modules/diffusion.py
+++ b/src/boltz/model/modules/diffusion.py
@@ -736,7 +736,7 @@ class AtomDiffusion(Module):
         noise = torch.randn_like(atom_coords)
         noised_atom_coords = atom_coords + padded_sigmas * noise
 
-        denoised_atom_coords = self.preconditioned_network_forward(
+        denoised_atom_coords, _ = self.preconditioned_network_forward(
             noised_atom_coords,
             sigmas,
             training=True,

--- a/src/boltz/model/modules/diffusionv2.py
+++ b/src/boltz/model/modules/diffusionv2.py
@@ -554,7 +554,7 @@ class AtomDiffusion(Module):
         noise = torch.randn_like(atom_coords)
         noised_atom_coords = atom_coords + padded_sigmas * noise
 
-        denoised_atom_coords, _ = self.preconditioned_network_forward(
+        denoised_atom_coords = self.preconditioned_network_forward(
             noised_atom_coords,
             sigmas,
             network_condition_kwargs={

--- a/src/boltz/model/modules/trunkv2.py
+++ b/src/boltz/model/modules/trunkv2.py
@@ -651,7 +651,7 @@ class MSAModule(nn.Module):
                     chunk_size_transition_msa,
                     chunk_size_outer_product,
                     chunk_size_tri_attn,
-                    use_kernels=use_kernels,
+                    use_kernels,
                 )
             else:
                 z, m = self.layers[i](
@@ -664,7 +664,7 @@ class MSAModule(nn.Module):
                     chunk_size_transition_msa,
                     chunk_size_outer_product,
                     chunk_size_tri_attn,
-                    use_kernels=use_kernels,
+                    use_kernels,
                 )
         return z
 


### PR DESCRIPTION
Remove unused return value in diffusion.forward() (used during v2 training), convert use_kernels argument to positional only for torch>2.2 compatibility.