### PR TITLE
Fix pocket_constraints assignment in PredictionDataset

### DIFF
--- a/src/boltz/data/module/inferencev2.py
+++ b/src/boltz/data/module/inferencev2.py
@@ -261,7 +261,7 @@ class PredictionDataset(torch.utils.data.Dataset):
         # Inference specific options
         options = record.inference_options
         if options is None:
-            pocket_constraints = None, None
+            pocket_constraints = None
         else:
             pocket_constraints = options.pocket_constraints
 


### PR DESCRIPTION
Fix pocket_constraints assignment in PredictionDataset
inferencev2:
```
        # Inference specific options
        options = record.inference_options
        if options is None:
            pocket_constraints = None, None
        else:
            pocket_constraints = options.pocket_constraints
```

featurizerv2:
```
    if inference_pocket_constraints is not None:
        for binder, contacts, max_distance in inference_pocket_constraints:
            binder_mask = token_data["asym_id"] == binder
```