### PR TITLE
Update mols.tar download logic

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -206,13 +206,19 @@ def download_boltz2(cache: Path) -> None:
     # Download CCD
     mols = cache / "mols"
     tar_mols = cache / "mols.tar"
-    if not mols.exists():
+    if not tar_mols.exists():
         click.echo(
-            f"Downloading and extracting the CCD data to {mols}. "
+            f"Downloading the CCD data to {tar_mols}. "
             "This may take a bit of time. You may change the cache directory "
             "with the --cache flag."
         )
         urllib.request.urlretrieve(MOL_URL, str(tar_mols))  # noqa: S310
+    if not mols.exists():
+        click.echo(
+            f"Extracting the CCD data to {mols}. "
+            "This may take a bit of time. You may change the cache directory "
+            "with the --cache flag."
+        )
         with tarfile.open(str(tar_mols), "r") as tar:
             tar.extractall(cache)  # noqa: S202
 


### PR DESCRIPTION
Related to #295 

The current logic for downloading the mols.tar archive at runtime goes like this:
1. Is there a folder named "mols" in the cache directory?
2. If not, download and extract mols.tar from HuggingFace

However, if you download the model weights from HuggingFace ahead of time but don't extract them, the existing logic wouldn't see a "mols" folder and try to download and extract the results. Why is this a problem? Because some HPC platforms allow users to download stuff from the internet ahead of time but not during a run. Some NextFlow environments (Like AWS HealthOmics) are like this. In those cases, you can reference external data dependencies which are "automagically" loaded into a working directory before the start of a run but not always extracted. You need to write some custom code to do so before calling `boltz predict`.

This PR updates the logic a bit to break apart the download and extract steps. So, the new logic looks like:
1. Is there a file named "mols.tar" in the cache director?
2. If not, download it.
3. Is there a folder named "mols" in the cache directory?
4. If not, extract mols.tar 