### PR TITLE
Fix for use_kernels for later torch versions for PairformerNoSeqModule

### DIFF
--- a/src/boltz/model/layers/pairformer.py
+++ b/src/boltz/model/layers/pairformer.py
@@ -325,13 +325,13 @@ class PairformerNoSeqModule(nn.Module):
                     z,
                     pair_mask,
                     chunk_size_tri_attn,
-                    use_kernels=use_kernels,
+                    use_kernels,
                 )
             else:
                 z = layer(
                     z,
                     pair_mask,
                     chunk_size_tri_attn,
-                    use_kernels=use_kernels,
+                    use_kernels,
                 )
         return z


### PR DESCRIPTION
Make use_kernels positional arg in PairformerNoSeqModule to avoid torch issues when use_reentrant=False is not passed. 