### PR TITLE
Fix affinity prediction for large molecules and enable embedding export

### DIFF
--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -1782,6 +1782,9 @@ def standardize(smiles: str) -> Optional[str]:
     if exclude:
         raise ValueError("Molecule is excluded")
 
+    # Update property cache to calculate implicit valences before fragment selection
+    mol.UpdatePropertyCache(strict=False)
+
     # Standardize with ChEMBL data curation pipeline. During standardization, the molecule may be broken
     # Choose molecule with largest component
     mol = LARGEST_FRAGMENT_CHOOSER.choose(mol)

--- a/src/boltz/data/write/writer.py
+++ b/src/boltz/data/write/writer.py
@@ -94,6 +94,32 @@ class BoltzWriter(BasePredictionWriter):
             # Remove masked chains completely
             structure = structure.remove_invalid_chains()
 
+            # --- Save embeddings and masks (once per record) ---
+            struct_dir = self.output_dir / record.id
+            struct_dir.mkdir(exist_ok=True)
+
+            if "s_embeddings" in prediction:
+                # Take the first element from the batch dimension (index 0)
+                s_embeddings = prediction["s_embeddings"][0] 
+                path = struct_dir / f"s_embeddings_{record.id}.npz"
+                np.savez_compressed(path, s_embeddings=s_embeddings.cpu().numpy())
+
+            if "z_embeddings" in prediction:
+                z_embeddings = prediction["z_embeddings"][0]
+                path = struct_dir / f"z_embeddings_{record.id}.npz"
+                np.savez_compressed(path, z_embeddings=z_embeddings.cpu().numpy())
+            
+            if "token_mask" in prediction:
+                token_mask = prediction["token_mask"][0]
+                path = struct_dir / f"token_mask_{record.id}.npz"
+                np.savez_compressed(path, token_mask=token_mask.cpu().numpy())
+            
+            if "pair_mask" in prediction:
+                pair_mask = prediction["pair_mask"][0]
+                path = struct_dir / f"pair_mask_{record.id}.npz"
+                np.savez_compressed(path, pair_mask=pair_mask.cpu().numpy())
+            # --- End of embeddings/masks saving ---
+
             for model_idx in range(coord.shape[0]):
                 # Get model coord
                 model_coord = coord[model_idx]

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -823,6 +823,12 @@ def cli() -> None:
     help="Whether to dump the pde into a npz file. Default is False.",
 )
 @click.option(
+    "--write_embeddings",
+    type=bool,
+    is_flag=True,
+    help="Whether to save the sequence and pairwise embeddings. Default is False.",
+)
+@click.option(
     "--output_format",
     type=click.Choice(["pdb", "mmcif"]),
     help="The output format to use for the predictions. Default is mmcif.",
@@ -951,6 +957,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
     step_scale: Optional[float] = None,
     write_full_pae: bool = False,
     write_full_pde: bool = False,
+    write_embeddings: bool = False,
     output_format: Literal["pdb", "mmcif"] = "mmcif",
     num_workers: int = 2,
     override: bool = False,

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -1179,6 +1179,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
             "write_confidence_summary": True,
             "write_full_pae": write_full_pae,
             "write_full_pde": write_full_pde,
+            "write_embeddings": write_embeddings,
         }
 
         steering_args = BoltzSteeringParams()

--- a/src/boltz/model/models/boltz1.py
+++ b/src/boltz/model/models/boltz1.py
@@ -340,7 +340,7 @@ class Boltz1(LightningModule):
                     )
 
             pdistogram = self.distogram_module(z)
-            dict_out = {"pdistogram": pdistogram}
+            dict_out = {"pdistogram": pdistogram, "s_embeddings": s, "z_embeddings": z, "token_mask": mask, "pair_mask": pair_mask}
 
         # Compute structure module
         if self.training and self.structure_prediction_training:
@@ -1159,6 +1159,11 @@ class Boltz1(LightningModule):
             pred_dict = {"exception": False}
             pred_dict["masks"] = batch["atom_pad_mask"]
             pred_dict["coords"] = out["sample_atom_coords"]
+            if self.predict_args.get("write_embeddings", False):
+                pred_dict["s_embeddings"] = out["s_embeddings"]
+                pred_dict["z_embeddings"] = out["z_embeddings"]
+                pred_dict["token_mask"] = out["token_mask"]
+                pred_dict["pair_mask"] = out["pair_mask"]
             if self.predict_args.get("write_confidence_summary", True):
                 pred_dict["confidence_score"] = (
                     4 * out["complex_plddt"]

--- a/src/boltz/model/models/boltz2.py
+++ b/src/boltz/model/models/boltz2.py
@@ -10,14 +10,10 @@ from torchmetrics import MeanMetric
 
 import boltz.model.layers.initialize as init
 from boltz.data import const
-from boltz.data.mol import (
-    minimum_lddt_symmetry_coords,
-)
+from boltz.data.mol import minimum_lddt_symmetry_coords
 from boltz.model.layers.pairformer import PairformerModule
 from boltz.model.loss.bfactor import bfactor_loss_fn
-from boltz.model.loss.confidencev2 import (
-    confidence_loss,
-)
+from boltz.model.loss.confidencev2 import confidence_loss
 from boltz.model.loss.distogramv2 import distogram_loss
 from boltz.model.modules.affinity import AffinityModule
 from boltz.model.modules.confidencev2 import ConfidenceModule
@@ -113,7 +109,9 @@ class Boltz2(LightningModule):
 
         if validate_structure:
             # Late init at setup time
-            self.val_group_mapper = {}  # maps a dataset index to a validation group name
+            self.val_group_mapper = (
+                {}
+            )  # maps a dataset index to a validation group name
             self.validator_mapper = {}  # maps a dataset index to a validator
 
             # Validators for each dataset keep track of all metrics,
@@ -457,7 +455,9 @@ class Boltz2(LightningModule):
                         # Compute pairwise stack
                         if self.use_templates:
                             if self.is_template_compiled and not self.training:
-                                template_module = self.template_module._orig_mod  # noqa: SLF001
+                                template_module = (
+                                    self.template_module._orig_mod
+                                )  # noqa: SLF001
                             else:
                                 template_module = self.template_module
 
@@ -476,7 +476,9 @@ class Boltz2(LightningModule):
 
                         # Revert to uncompiled version for validation
                         if self.is_pairformer_compiled and not self.training:
-                            pairformer_module = self.pairformer_module._orig_mod  # noqa: SLF001
+                            pairformer_module = (
+                                self.pairformer_module._orig_mod
+                            )  # noqa: SLF001
                         else:
                             pairformer_module = self.pairformer_module
 
@@ -489,7 +491,13 @@ class Boltz2(LightningModule):
                         )
 
             pdistogram = self.distogram_module(z)
-            dict_out = {"pdistogram": pdistogram}
+            dict_out = {
+                "pdistogram": pdistogram,
+                "s_embeddings": s,
+                "z_embeddings": z,
+                "token_mask": mask,
+                "pair_mask": pair_mask,
+            }
 
             if (
                 self.run_trunk_and_structure
@@ -1072,6 +1080,11 @@ class Boltz2(LightningModule):
                 for key in self.predict_args["keys_dict_out"]:
                     pred_dict[key] = out[key]
             pred_dict["coords"] = out["sample_atom_coords"]
+            if self.predict_args.get("write_embeddings", False):
+                pred_dict["s_embeddings"] = out["s_embeddings"]
+                pred_dict["z_embeddings"] = out["z_embeddings"]
+                pred_dict["token_mask"] = out["token_mask"]
+                pred_dict["pair_mask"] = out["pair_mask"]
             if self.confidence_prediction:
                 # pred_dict["confidence"] = out.get("ablation_confidence", None)
                 pred_dict["pde"] = out["pde"]
@@ -1230,12 +1243,12 @@ class Boltz2(LightningModule):
             checkpoint["hyper_parameters"]["training_args"][
                 "diffusion_multiplicity"
             ] = self.training_args.diffusion_multiplicity
-            checkpoint["hyper_parameters"]["training_args"]["recycling_steps"] = (
-                self.training_args.recycling_steps
-            )
-            checkpoint["hyper_parameters"]["training_args"]["weight_decay"] = (
-                self.training_args.weight_decay
-            )
+            checkpoint["hyper_parameters"]["training_args"][
+                "recycling_steps"
+            ] = self.training_args.recycling_steps
+            checkpoint["hyper_parameters"]["training_args"][
+                "weight_decay"
+            ] = self.training_args.weight_decay
 
     def configure_callbacks(self) -> list[Callback]:
         """Configure model callbacks.

--- a/tests/test_standardization.py
+++ b/tests/test_standardization.py
@@ -1,0 +1,123 @@
+"""Test suite for molecule standardization in affinity prediction.
+
+This module tests the standardize function used in affinity prediction to ensure
+it correctly handles complex multi-component molecules. The tests verify that
+the RDKit implicit valence calculation fix prevents runtime errors when processing
+molecules with multiple disconnected components, charged species, and complex
+stereochemistry.
+
+The fix addresses a bug where LARGEST_FRAGMENT_CHOOSER.choose() was called on
+molecules created with sanitize=False without first calculating implicit valences,
+causing "getNumImplicitHs() called without preceding call to calcImplicitValence()"
+errors for certain complex molecular structures.
+"""
+
+import unittest
+
+from boltz.data.parse.schema import standardize
+
+
+class TestMoleculeStandardization(unittest.TestCase):
+    """Test cases for molecule standardization in affinity prediction."""
+
+    def test_standardize_simple_molecule(self):
+        """Test standardization of a simple organic molecule.
+
+        This test verifies that the standardize function works correctly
+        for basic molecules that don't trigger the implicit valence bug.
+        """
+        smiles = "CCO"  # Ethanol
+
+        result = standardize(smiles)
+
+        # Should return a valid SMILES string
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+        # For ethanol, the standardized form should be the same or equivalent
+        self.assertEqual(result, "CCO")
+
+    def test_standardize_amino_acid(self):
+        """Test standardization of an amino acid (tyrosine).
+
+        This test uses the same molecule from the official Boltz examples
+        to ensure compatibility with known working cases.
+        """
+        smiles = "N[C@@H](Cc1ccc(O)cc1)C(=O)O"  # Tyrosine
+
+        result = standardize(smiles)
+
+        # Should return a valid SMILES string
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+        # Should contain the key structural elements
+        self.assertIn("N", result)
+        self.assertIn("O", result)
+
+    def test_standardize_complex_multicomponent_molecule(self):
+        """Test standardization of complex multi-component molecules.
+
+        This test specifically targets the bug where complex molecules with
+        multiple disconnected components, charged species, and phosphate groups
+        would cause RDKit to fail with implicit valence errors. The molecule
+        tested here contains:
+        - Multiple disconnected components (separated by '.')
+        - Charged species ([H+])
+        - Complex nucleotide-like structures with phosphate groups
+        - Stereochemistry markers
+
+        Before the fix, this would raise:
+        RuntimeError: Pre-condition Violation
+        getNumImplicitHs() called without preceding call to calcImplicitValence()
+        """
+        # Complex multi-component molecule that previously caused the error
+        smiles = (
+            "O=Cc1ccccc1.C#CCN.NC(=O)C1=CN(C=CC1)[C@@H]1O[C@H]"
+            "(COP(O)(=O)OP(O)(=O)OC[C@H]2O[C@H]([C@H](O)[C@@H]2O)"
+            "n2cnc3c(N)ncnc23)[C@@H](O)[C@H]1O.[H+]"
+        )
+
+        # This should not raise an exception after the fix
+        result = standardize(smiles)
+
+        # Should return a valid SMILES string
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+        # The result should be different from input due to standardization
+        # (fragment selection, canonicalization, etc.)
+        self.assertNotEqual(result, smiles)
+
+    def test_standardize_molecule_with_charged_species(self):
+        """Test standardization of molecules containing charged species.
+
+        Charged species can be particularly problematic for implicit valence
+        calculations, so this test ensures they are handled correctly.
+        """
+        smiles = "C[NH3+]"  # Methylammonium ion
+
+        result = standardize(smiles)
+
+        # Should return a valid SMILES string
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+
+    def test_standardize_preserves_largest_fragment(self):
+        """Test that standardization correctly selects the largest fragment.
+
+        The LARGEST_FRAGMENT_CHOOSER should select the most significant
+        component from multi-component molecules.
+        """
+        # Molecule with small and large fragments
+        smiles = "O.CCCCCCCCCCCCCCCCCC"  # Water + long alkyl chain
+
+        result = standardize(smiles)
+
+        # Should return only the larger fragment (alkyl chain)
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+        # Should not contain the water molecule
+        self.assertNotIn("O.", result)
+        self.assertNotIn(".O", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR introduces comprehensive improvements to Boltz's embedding extraction capabilities and resolves critical issues with affinity prediction for complex molecules.

## 🚀 Features Added

### Embedding Extraction Support
- **New CLI option**: `--write_embeddings` flag to control saving of sequence and pairwise embeddings
- **Enhanced BoltzWriter**: Now saves `s_embeddings`, `z_embeddings`, `token_mask`, and `pair_mask` to compressed `.npz` files

## 🐛 Bug Fixes

### Affinity Prediction Stability
- **Fixed RDKit implicit valence error** that caused crashes when processing complex multi-component molecules
- **Root cause**: Missing `UpdatePropertyCache()` call before fragment selection in molecule standardization
- **Impact**: Enables affinity prediction for molecules with:
  - Multiple disconnected components
  - Charged species ([H+], etc.)
  - Complex stereochemistry and phosphate groups
  - Nucleotide-like structures

## 🧪 Testing
- Comprehensive test suite for standardization, covering simple molecules, amino acids, and complex multi-component structures
- All existing functionality preserved with backward compatibility

## 📝 Technical Details
- Embedding extraction now works consistently across both Boltz1 and Boltz2 models
- Clean separation of embedding/mask saving logic from diffusion sampling loops

These changes enable researchers to extract intermediate representations from Boltz models while ensuring robust handling of diverse molecular structures in affinity prediction tasks.