### PR TITLE
Fix over-eager skip logic in filter_inputs_structure

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -337,9 +337,12 @@ def filter_inputs_structure(
         The manifest of the filtered input data.
 
     """
-    # Check if existing predictions are found
-    existing = (outdir / "predictions").rglob("*")
-    existing = {e.name for e in existing if e.is_dir()}
+    # Check if existing predictions are found (only top-level prediction folders)
+    pred_dir = outdir / "predictions"
+    if pred_dir.exists():
+        existing = {d.name for d in pred_dir.iterdir() if d.is_dir()}
+    else:
+        existing = set()
 
     # Remove them from the input data
     if existing and not override:


### PR DESCRIPTION
### Description
[filter_inputs_structure](cci:1://file:///c:/Users/T2430514/Downloads/boltz/src/boltz/main.py:317:0-360:19) tried to detect completed predictions by recursively
listing everything under `out_dir/predictions/`, causing any nested directories
or files to be mistaken for record IDs.  
The function now inspects only the **immediate sub-directories** of
`predictions/`, which represent actual prediction folders.  
This restores correct skipping behaviour and guarantees that legitimate,
unprocessed targets are not silently ignored.