### PR TITLE
Improve `TrainingDataset __getitem__` performance

### DIFF
--- a/src/boltz/data/feature/featurizer.py
+++ b/src/boltz/data/feature/featurizer.py
@@ -1,7 +1,7 @@
 import math
 import random
 from typing import Optional
-
+from collections import deque
 import numba
 import numpy as np
 import numpy.typing as npt
@@ -210,9 +210,9 @@ def construct_paired_msa(  # noqa: C901, PLR0915, PLR0912
     visited = {(c, s) for c, items in taxonomy_map for s in items}
     available = {}
     for c in chain_ids:
-        available[c] = [
+        available[c] = deque(
             i for i in range(1, len(msa[c].sequences)) if (c, i) not in visited
-        ]
+        )
 
     # Create sequence pairs
     is_paired = []
@@ -252,8 +252,7 @@ def construct_paired_msa(  # noqa: C901, PLR0915, PLR0912
                     row_is_paired[chain_id] = 0
                     if available[chain_id]:
                         # Add the next available sequence
-                        seq_idx = available[chain_id].pop(0)
-                        row_pairing[chain_id] = seq_idx
+                        row_pairing[chain_id] = available[chain_id].popleft()
                     else:
                         # No more sequences available, we place a gap
                         row_pairing[chain_id] = -1
@@ -278,8 +277,7 @@ def construct_paired_msa(  # noqa: C901, PLR0915, PLR0912
             row_is_paired[chain_id] = 0
             if available[chain_id]:
                 # Add the next available sequence
-                seq_idx = available[chain_id].pop(0)
-                row_pairing[chain_id] = seq_idx
+                row_pairing[chain_id] = available[chain_id].popleft()
             else:
                 # No more sequences available, we place a gap
                 row_pairing[chain_id] = -1

--- a/src/boltz/data/feature/featurizerv2.py
+++ b/src/boltz/data/feature/featurizerv2.py
@@ -1,6 +1,6 @@
 import math
 from typing import Optional
-
+from collections import deque
 import numba
 import numpy as np
 import numpy.typing as npt
@@ -324,9 +324,9 @@ def construct_paired_msa(  # noqa: C901, PLR0915, PLR0912
     visited = {(c, s) for c, items in taxonomy_map for s in items}
     available = {}
     for c in chain_ids:
-        available[c] = [
+        available[c] = deque(
             i for i in range(1, len(msa[c].sequences)) if (c, i) not in visited
-        ]
+        )
 
     # Create sequence pairs
     is_paired = []
@@ -366,8 +366,7 @@ def construct_paired_msa(  # noqa: C901, PLR0915, PLR0912
                     row_is_paired[chain_id] = 0
                     if available[chain_id]:
                         # Add the next available sequence
-                        seq_idx = available[chain_id].pop(0)
-                        row_pairing[chain_id] = seq_idx
+                        row_pairing[chain_id] = available[chain_id].popleft()
                     else:
                         # No more sequences available, we place a gap
                         row_pairing[chain_id] = -1
@@ -392,8 +391,7 @@ def construct_paired_msa(  # noqa: C901, PLR0915, PLR0912
             row_is_paired[chain_id] = 0
             if available[chain_id]:
                 # Add the next available sequence
-                seq_idx = available[chain_id].pop(0)
-                row_pairing[chain_id] = seq_idx
+                row_pairing[chain_id] = available[chain_id].popleft()
             else:
                 # No more sequences available, we place a gap
                 row_pairing[chain_id] = -1

--- a/src/boltz/data/feature/featurizerv2.py
+++ b/src/boltz/data/feature/featurizerv2.py
@@ -419,18 +419,22 @@ def construct_paired_msa(  # noqa: C901, PLR0915, PLR0912
         is_paired = is_paired[:max_seqs]
 
     # Map (chain_id, seq_idx, res_idx) to deletion
-    deletions = {}
+    deletions = numba.typed.Dict.empty(
+        key_type=numba.types.Tuple(
+            [numba.types.int64, numba.types.int64, numba.types.int64]),
+        value_type=numba.types.int64
+    )
     for chain_id, chain_msa in msa.items():
         chain_deletions = chain_msa.deletions
         for sequence in chain_msa.sequences:
+            seq_idx = sequence["seq_idx"]
             del_start = sequence["del_start"]
             del_end = sequence["del_end"]
-            chain_deletions = chain_msa.deletions[del_start:del_end]
+            chain_deletions = chain_deletions[del_start:del_end]
             for deletion_data in chain_deletions:
-                seq_idx = sequence["seq_idx"]
                 res_idx = deletion_data["res_idx"]
-                deletion = deletion_data["deletion"]
-                deletions[(chain_id, seq_idx, res_idx)] = deletion
+                deletion_values = deletion_data["deletion"]
+                deletions[(chain_id, seq_idx, res_idx)] = deletion_values
 
     # Add all the token MSA data
     msa_data, del_data, paired_data = prepare_msa_arrays(
@@ -491,21 +495,13 @@ def prepare_msa_arrays(
         chain_idx = chain_id_to_idx[chain_id]
         msa_residues[chain_idx, idxs] = residues
 
-    deletions_dict = numba.typed.Dict.empty(
-        key_type=numba.types.Tuple(
-            [numba.types.int64, numba.types.int64, numba.types.int64]
-        ),
-        value_type=numba.types.int64,
-    )
-    deletions_dict.update(deletions)
-
     return _prepare_msa_arrays_inner(
         token_asym_ids_arr,
         token_res_idxs_arr,
         token_asym_ids_idx_arr,
         pairing_arr,
         is_paired_arr,
-        deletions_dict,
+        deletions,
         msa_sequences,
         msa_residues,
         const.token_ids["-"],

--- a/src/boltz/data/tokenize/boltz.py
+++ b/src/boltz/data/tokenize/boltz.py
@@ -1,4 +1,4 @@
-from dataclasses import astuple, dataclass
+from dataclasses import dataclass
 
 import numpy as np
 

--- a/src/boltz/data/tokenize/boltz.py
+++ b/src/boltz/data/tokenize/boltz.py
@@ -29,6 +29,28 @@ class TokenData:
     cyclic_period: int
 
 
+def token_astuple(token: TokenData) -> tuple:
+    """Convert a TokenData object to a tuple."""
+    return (
+        token.token_idx,
+        token.atom_idx,
+        token.atom_num,
+        token.res_idx,
+        token.res_type,
+        token.sym_id,
+        token.asym_id,
+        token.entity_id,
+        token.mol_type,
+        token.center_idx,
+        token.disto_idx,
+        token.center_coords,
+        token.disto_coords,
+        token.resolved_mask,
+        token.disto_mask,
+        token.cyclic_period,
+    )
+
+
 class BoltzTokenizer(Tokenizer):
     """Tokenize an input structure for training."""
 
@@ -102,7 +124,7 @@ class BoltzTokenizer(Tokenizer):
                         disto_mask=is_disto_present,
                         cyclic_period=chain["cyclic_period"],
                     )
-                    token_data.append(astuple(token))
+                    token_data.append(token_astuple(token))
 
                     # Update atom_idx to token_idx
                     for atom_idx in range(atom_start, atom_end):
@@ -147,7 +169,7 @@ class BoltzTokenizer(Tokenizer):
                                 "cyclic_period"
                             ],  # Enforced to be False in chain parser
                         )
-                        token_data.append(astuple(token))
+                        token_data.append(token_astuple(token))
 
                         # Update atom_idx to token_idx
                         atom_to_token[index] = token_idx

--- a/src/boltz/data/tokenize/boltz.py
+++ b/src/boltz/data/tokenize/boltz.py
@@ -127,8 +127,8 @@ class BoltzTokenizer(Tokenizer):
                     token_data.append(token_astuple(token))
 
                     # Update atom_idx to token_idx
-                    for atom_idx in range(atom_start, atom_end):
-                        atom_to_token[atom_idx] = token_idx
+                    atom_to_token.update(
+                        dict.fromkeys(range(atom_start, atom_end), token_idx))
 
                     token_idx += 1
 

--- a/src/boltz/data/tokenize/boltz2.py
+++ b/src/boltz/data/tokenize/boltz2.py
@@ -249,8 +249,8 @@ def tokenize_structure(  # noqa: C901, PLR0915
                 token_data.append(token_astuple(token))
 
                 # Update atom_idx to token_idx
-                for atom_idx in range(atom_start, atom_end):
-                    atom_to_token[atom_idx] = token_idx
+                atom_to_token.update(
+                    dict.fromkeys(range(atom_start, atom_end), token_idx))
 
                 token_idx += 1
 
@@ -348,8 +348,8 @@ def tokenize_structure(  # noqa: C901, PLR0915
                 token_data.append(token_astuple(token))
 
                 # Update atom_idx to token_idx
-                for atom_idx in range(atom_start, atom_end):
-                    atom_to_token[atom_idx] = token_idx
+                atom_to_token.update(
+                    dict.fromkeys(range(atom_start, atom_end), token_idx))
 
                 token_idx += 1
 

--- a/src/boltz/data/tokenize/boltz2.py
+++ b/src/boltz/data/tokenize/boltz2.py
@@ -1,4 +1,4 @@
-from dataclasses import astuple, dataclass
+from dataclasses import dataclass
 from typing import Optional
 
 import numpy as np
@@ -41,6 +41,33 @@ class TokenData:
     frame_mask: bool
     cyclic_period: int
     affinity_mask: bool = False
+
+
+def token_astuple(token: TokenData) -> tuple:
+    """Convert a TokenData object to a tuple."""
+    return (
+        token.atom_idx,
+        token.atom_num,
+        token.res_idx,
+        token.res_type,
+        token.res_name,
+        token.sym_id,
+        token.asym_id,
+        token.entity_id,
+        token.mol_type,
+        token.center_idx,
+        token.disto_idx,
+        token.center_coords,
+        token.disto_coords,
+        token.resolved_mask,
+        token.disto_mask,
+        token.modified,
+        token.frame_rot,
+        token.frame_t,
+        token.frame_mask,
+        token.cyclic_period,
+        token.affinity_mask,
+    )
 
 
 def compute_frame(
@@ -219,7 +246,7 @@ def tokenize_structure(  # noqa: C901, PLR0915
                     cyclic_period=chain["cyclic_period"],
                     affinity_mask=affinity_mask,
                 )
-                token_data.append(astuple(token))
+                token_data.append(token_astuple(token))
 
                 # Update atom_idx to token_idx
                 for atom_idx in range(atom_start, atom_end):
@@ -271,7 +298,7 @@ def tokenize_structure(  # noqa: C901, PLR0915
                         cyclic_period=chain["cyclic_period"],
                         affinity_mask=affinity_mask,
                     )
-                    token_data.append(astuple(token))
+                    token_data.append(token_astuple(token))
 
                     # Update atom_idx to token_idx
                     atom_to_token[index] = token_idx
@@ -318,7 +345,7 @@ def tokenize_structure(  # noqa: C901, PLR0915
                     cyclic_period=chain["cyclic_period"],
                     affinity_mask=affinity_mask,
                 )
-                token_data.append(astuple(token))
+                token_data.append(token_astuple(token))
 
                 # Update atom_idx to token_idx
                 for atom_idx in range(atom_start, atom_end):


### PR DESCRIPTION
While exploring the Boltz codebase, I spotted a few low-hanging fruits to optimize the `__getitem__` method in `TrainingDataset`. I used `cProfile` to compare timings before and after, and as profiling data I used samples from the [preprocessed RCSB dataset](https://github.com/jwohlwend/boltz/blob/main/docs/training.md#download-the-pre-processed-data). During the profiling, I set the seed to 42 for both sampling and cropping (the non-deterministic steps), and I ran the profiling on the same data points (N=10).

Key changes:
	•	In `tokenize()`, replaced the recursive `astuple()` with a faster, direct conversion (`token_astuple`).
	•	Batched the `atom_to_token` update instead of assigning one key at a time.
	•	In `construct_paired_msa`, replaced lists with deque to get O(1) `popleft()` calls.
	•	In `prepare_msa_arrays`, built the Numba-typed dictionary directly, removing the intermediate Python one.

Results (per `__getitem__` call), averaged on 10 samples:
	•	Total: 0.59s (down from 1.06s)
	•	Tokenization: 0.07s (down from 0.46s)
	•	Featurization: 0.24s (down from 0.33s)

Changes were applied to both v1 and v2, though profiling was only done on v1 as v2 doesn’t currently run for me (which seems expected per README).