### PR TITLE
Fix template matched 

### DIFF
--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -1593,15 +1593,17 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
         if (
             template_chain_ids is not None
             and chain_ids is not None
-            and len(template_chain_ids) != len(chain_ids)
         ):
-            matched = True
-            if len(template_chain_ids) != len(chain_ids):
-                msg = (
-                    "When providing both the chain_id and template_id, the number of"
-                    "template_ids provided must match the number of chain_ids!"
-                )
-                raise ValueError(msg)
+           
+                if len(template_chain_ids) == len(chain_ids):
+                     if len(template_chain_ids) > 0 and len(chain_ids) > 0:
+                        matched = True
+                else:
+                    msg = (
+                        "When providing both the chain_id and template_id, the number of"
+                        "template_ids provided must match the number of chain_ids!"
+                    )
+                    raise ValueError(msg)
 
         # Get relevant chains ids
         if chain_ids is None:


### PR DESCRIPTION
User input chain_ids and template_chain_ids will never make matched=True.  Set matched = True when both are not empty and have the same length.