### PR TITLE
Manifest which checks the existence of affinity info

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -404,7 +404,7 @@ def filter_inputs_affinity(
         msg = "Found existing affinity predictions, will override."
         click.echo(msg)
 
-    return Manifest([r for r in manifest.records if r.id not in existing])
+    return Manifest([r for r in manifest.records if r.affinity and r.id not in existing])
 
 
 def compute_msa(


### PR DESCRIPTION
Fixes #448

Tested with the same set of input files and this is the result

```
output/boltz_results_input_data/predictions/
├── aff
│   ├── aff_model_0.cif
│   ├── affinity_aff.json
│   ├── confidence_aff_model_0.json
│   ├── pae_aff_model_0.npz
│   ├── pde_aff_model_0.npz
│   ├── plddt_aff_model_0.npz
│   └── pre_affinity_aff.npz
├── pocket
│   ├── confidence_pocket_model_0.json
│   ├── pae_pocket_model_0.npz
│   ├── pde_pocket_model_0.npz
│   ├── plddt_pocket_model_0.npz
│   └── pocket_model_0.cif
└── something
    ├── confidence_something_model_0.json
    ├── pae_something_model_0.npz
    ├── pde_something_model_0.npz
    ├── plddt_something_model_0.npz
    └── something_model_0.cif

3 directories, 17 files
root@modal:/home/coder# 
```