### PR TITLE
Add support for dumping embeddings during prediction

### DIFF
--- a/src/boltz/data/write/writer.py
+++ b/src/boltz/data/write/writer.py
@@ -23,6 +23,7 @@ class BoltzWriter(BasePredictionWriter):
         output_dir: str,
         output_format: Literal["pdb", "mmcif"] = "mmcif",
         boltz2: bool = False,
+        write_embeddings: bool = False,
     ) -> None:
         """Initialize the writer.
 
@@ -43,6 +44,7 @@ class BoltzWriter(BasePredictionWriter):
         self.failed = 0
         self.boltz2 = boltz2
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.write_embeddings = write_embeddings
 
     def write_on_batch_end(
         self,
@@ -243,6 +245,17 @@ class BoltzWriter(BasePredictionWriter):
                         / f"pde_{record.id}_model_{idx_to_rank[model_idx]}.npz"
                     )
                     np.savez_compressed(path, pde=pde.cpu().numpy())
+                
+            # Save embeddings
+            if self.write_embeddings and "s" in prediction and "z" in prediction:
+                s = prediction["s"].cpu().numpy()
+                z = prediction["z"].cpu().numpy()
+
+                path = (
+                    struct_dir
+                    / f"embeddings_{record.id}.npz"
+                )
+                np.savez_compressed(path, s=s, z=z)
 
     def on_predict_epoch_end(
         self,

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -934,6 +934,11 @@ def cli() -> None:
     is_flag=True,
     help="Whether to disable the kernels. Default False",
 )
+@click.option(
+    "--write_embeddings",
+    is_flag=True,
+    help=" to dump the s and z embeddings into a npz file. Default is False.",
+)
 def predict(  # noqa: C901, PLR0915, PLR0912
     data: str,
     out_dir: str,
@@ -967,6 +972,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
     subsample_msa: bool = True,
     num_subsampled_msa: int = 1024,
     no_kernels: bool = False,
+    write_embeddings: bool = False,
 ) -> None:
     """Run predictions with Boltz."""
     # If cpu, write a friendly warning
@@ -1118,6 +1124,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
         output_dir=out_dir / "predictions",
         output_format=output_format,
         boltz2=model == "boltz2",
+        write_embeddings=write_embeddings,
     )
 
     # Set up trainer

--- a/src/boltz/model/models/boltz1.py
+++ b/src/boltz/model/models/boltz1.py
@@ -340,7 +340,11 @@ class Boltz1(LightningModule):
                     )
 
             pdistogram = self.distogram_module(z)
-            dict_out = {"pdistogram": pdistogram}
+            dict_out = {
+                "pdistogram": pdistogram,
+                "s": s,
+                "z": z,
+            }
 
         # Compute structure module
         if self.training and self.structure_prediction_training:
@@ -1159,6 +1163,8 @@ class Boltz1(LightningModule):
             pred_dict = {"exception": False}
             pred_dict["masks"] = batch["atom_pad_mask"]
             pred_dict["coords"] = out["sample_atom_coords"]
+            pred_dict["s"] = out["s"]
+            pred_dict["z"] = out["z"]
             if self.predict_args.get("write_confidence_summary", True):
                 pred_dict["confidence_score"] = (
                     4 * out["complex_plddt"]

--- a/src/boltz/model/models/boltz2.py
+++ b/src/boltz/model/models/boltz2.py
@@ -489,7 +489,11 @@ class Boltz2(LightningModule):
                         )
 
             pdistogram = self.distogram_module(z)
-            dict_out = {"pdistogram": pdistogram}
+            dict_out = {
+                "pdistogram": pdistogram,
+                "s": s,
+                "z": z,
+            }
 
             if (
                 self.run_trunk_and_structure
@@ -1067,6 +1071,8 @@ class Boltz2(LightningModule):
 
             pred_dict["masks"] = batch["atom_pad_mask"]
             pred_dict["token_masks"] = batch["token_pad_mask"]
+            pred_dict["s"] = out["s"]
+            pred_dict["z"] = out["z"]
 
             if "keys_dict_out" in self.predict_args:
                 for key in self.predict_args["keys_dict_out"]:


### PR DESCRIPTION
This pull request introduces functionality to save embeddings (`s` and `z`) during the prediction process and updates the relevant methods and models to support this feature. The changes span multiple files, including updates to the writer class, CLI options, and model outputs.

### Summary

- Implemented way to dump the single and pair embedding representation coming out of the `Pairformer` to `npz` file, following the suggestion in: jwohlwend/boltz#87.
- Added argument to trigger saving embeddings during prediction.

### Issues

Related to issues jwohlwend/boltz#87 and jwohlwend/boltz#280.

### Details

- The `s` and `z` embeddings are added to the returned dictionary in the `forward` and `predict_step` method of both `Boltz1` and `Boltz2` models
- The `BoltzWriter` custom callback is modified to dump the embeddings similarly to what already implemented for other information to save, _e.g._, PAE and PDE.
- Added `--write_embeddings` CLI option to `predict` command in main script to enable saving embeddings, passed this parameter to the writer class in the `predict` function.