### PR TITLE
Adding MSA server security

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,50 +51,8 @@ There are two main predictions in the affinity output: `affinity_pred_value` and
 
 ## Authentication to MSA Server
 
-When using the `--use_msa_server` option with a server that requires authentication, you can provide credentials in one of two ways:
-
-### 1. Basic Authentication
-
-- Use the CLI options `--msa_server_username` and `--msa_server_password`.
-- Or, set the environment variables:
-  - `BOLTZ_MSA_USERNAME` (for the username)
-  - `BOLTZ_MSA_PASSWORD` (for the password, recommended for security)
-
-**Example:**
-```bash
-export BOLTZ_MSA_USERNAME=myuser
-export BOLTZ_MSA_PASSWORD=mypassword
-boltz predict ... --use_msa_server
-```
-Or:
-```bash
-boltz predict ... --use_msa_server --msa_server_username myuser --msa_server_password mypassword
-```
-
-### 2. API Key Authentication
-
-- Use the CLI options `--api_key_header` (default: `X-API-Key`) and `--api_key_value` to specify the header and value for API key authentication.
-- Or, set the API key value via the environment variable `MSA_API_KEY_VALUE` (recommended for security).
-
-**Example using CLI:**
-```bash
-boltz predict ... --use_msa_server --api_key_header X-API-Key --api_key_value <your-api-key>
-```
-
-**Example using environment variable:**
-```bash
-export MSA_API_KEY_VALUE=<your-api-key>
-boltz predict ... --use_msa_server --api_key_header X-API-Key
-```
-If both the CLI option and environment variable are set, the CLI option takes precedence.
-
-> If your server expects a different header, set `--api_key_header` accordingly (e.g., `--api_key_header X-Gravitee-Api-Key`).
-
----
-
-**Note:**  
-Only one authentication method (basic or API key) can be used at a time. If both are provided, the program will raise an error.
-
+When using the `--use_msa_server` option with a server that requires authentication, you can provide credentials in one of two ways. More information is available in our [prediction instructions](docs/prediction.md).
+ 
 ## Evaluation
 
 ⚠️ **Coming soon: updated evaluation code for Boltz-2!**

--- a/README.md
+++ b/README.md
@@ -49,6 +49,52 @@ boltz predict input_path --use_msa_server
 ### Binding Affinity Prediction
 There are two main predictions in the affinity output: `affinity_pred_value` and `affinity_probability_binary`. They are trained on largely different datasets, with different supervisions, and should be used in different contexts. The `affinity_probability_binary` field should be used to detect binders from decoys, for example in a hit-discovery stage. It's value ranges from 0 to 1 and represents the predicted probability that the ligand is a binder. The `affinity_pred_value` aims to measure the specific affinity of different binders and how this changes with small modifications of the molecule. This should be used in ligand optimization stages such as hit-to-lead and lead-optimization. It reports a binding affinity value as `log(IC50)`, derived from an `IC50` measured in `μM`. More details on how to run affinity predictions and parse the output can be found in our [prediction instructions](docs/prediction.md).
 
+## Authentication to MSA Server
+
+When using the `--use_msa_server` option with a server that requires authentication, you can provide credentials in one of two ways:
+
+### 1. Basic Authentication
+
+- Use the CLI options `--msa_server_username` and `--msa_server_password`.
+- Or, set the environment variables:
+  - `BOLTZ_MSA_USERNAME` (for the username)
+  - `BOLTZ_MSA_PASSWORD` (for the password, recommended for security)
+
+**Example:**
+```bash
+export BOLTZ_MSA_USERNAME=myuser
+export BOLTZ_MSA_PASSWORD=mypassword
+boltz predict ... --use_msa_server
+```
+Or:
+```bash
+boltz predict ... --use_msa_server --msa_server_username myuser --msa_server_password mypassword
+```
+
+### 2. API Key Authentication
+
+- Use the CLI options `--api_key_header` (default: `X-API-Key`) and `--api_key_value` to specify the header and value for API key authentication.
+- Or, set the API key value via the environment variable `MSA_API_KEY_VALUE` (recommended for security).
+
+**Example using CLI:**
+```bash
+boltz predict ... --use_msa_server --api_key_header X-API-Key --api_key_value <your-api-key>
+```
+
+**Example using environment variable:**
+```bash
+export MSA_API_KEY_VALUE=<your-api-key>
+boltz predict ... --use_msa_server --api_key_header X-API-Key
+```
+If both the CLI option and environment variable are set, the CLI option takes precedence.
+
+> If your server expects a different header, set `--api_key_header` accordingly (e.g., `--api_key_header X-Gravitee-Api-Key`).
+
+---
+
+**Note:**  
+Only one authentication method (basic or API key) can be used at a time. If both are provided, the program will raise an error.
+
 ## Evaluation
 
 ⚠️ **Coming soon: updated evaluation code for Boltz-2!**

--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -21,6 +21,51 @@ Before diving into more details about the input formats, here are the key differ
 | Pocket conditioning | :x:                | :white_check_mark:   |
 | Affinity | :x:                | :white_check_mark:   |
 
+## Authentication to MSA Server
+
+When using the `--use_msa_server` option with a server that requires authentication, you can provide credentials in one of two ways:
+
+### 1. Basic Authentication
+
+- Use the CLI options `--msa_server_username` and `--msa_server_password`.
+- Or, set the environment variables:
+  - `BOLTZ_MSA_USERNAME` (for the username)
+  - `BOLTZ_MSA_PASSWORD` (for the password, recommended for security)
+
+**Example:**
+```bash
+export BOLTZ_MSA_USERNAME=myuser
+export BOLTZ_MSA_PASSWORD=mypassword
+boltz predict ... --use_msa_server
+```
+Or:
+```bash
+boltz predict ... --use_msa_server --msa_server_username myuser --msa_server_password mypassword
+```
+
+### 2. API Key Authentication
+
+- Use the CLI options `--api_key_header` (default: `X-API-Key`) and `--api_key_value` to specify the header and value for API key authentication.
+- Or, set the API key value via the environment variable `MSA_API_KEY_VALUE` (recommended for security).
+
+**Example using CLI:**
+```bash
+boltz predict ... --use_msa_server --api_key_header X-API-Key --api_key_value <your-api-key>
+```
+
+**Example using environment variable:**
+```bash
+export MSA_API_KEY_VALUE=<your-api-key>
+boltz predict ... --use_msa_server --api_key_header X-API-Key
+```
+If both the CLI option and environment variable are set, the CLI option takes precedence.
+
+> If your server expects a different header, set `--api_key_header` accordingly (e.g., `--api_key_header X-Gravitee-Api-Key`).
+
+---
+
+**Note:**  
+Only one authentication method (basic or API key) can be used at a time. If both are provided, the program will raise an error.
 
 
 ## YAML format

--- a/src/boltz/data/msa/mmseqs2.py
+++ b/src/boltz/data/msa/mmseqs2.py
@@ -5,9 +5,10 @@ import os
 import random
 import tarfile
 import time
-from typing import Union
+from typing import Optional, Union, Dict
 
 import requests
+from requests.auth import HTTPBasicAuth
 from tqdm import tqdm
 
 logger = logging.getLogger(__name__)
@@ -25,12 +26,50 @@ def run_mmseqs2(  # noqa: PLR0912, D103, C901, PLR0915
     use_pairing: bool = False,
     pairing_strategy: str = "greedy",
     host_url: str = "https://api.colabfold.com",
+    msa_server_username: Optional[str] = None,
+    msa_server_password: Optional[str] = None,
+    auth_headers: Optional[Dict[str, str]] = None,
+    api_key_header: Optional[str] = None,
+    api_key_value: Optional[str] = None,
 ) -> tuple[list[str], list[str]]:
     submission_endpoint = "ticket/pair" if use_pairing else "ticket/msa"
+
+    # Validate mutually exclusive authentication methods
+    has_basic_auth = msa_server_username and msa_server_password
+    has_header_auth = auth_headers is not None
+    has_api_key = api_key_value is not None
+    if has_basic_auth and (has_header_auth or has_api_key):
+        raise ValueError(
+            "Cannot use both basic authentication (username/password) and header/API key authentication. "
+            "Please use only one authentication method."
+        )
 
     # Set header agent as boltz
     headers = {}
     headers["User-Agent"] = "boltz"
+
+    # Set up authentication
+    auth = None
+    if has_basic_auth:
+        auth = HTTPBasicAuth(msa_server_username, msa_server_password)
+        logger.debug(f"MMSeqs2 server authentication: using basic auth for user '{msa_server_username}'")
+    elif has_header_auth:
+        headers.update(auth_headers)
+        logger.debug("MMSeqs2 server authentication: using header-based authentication")
+    elif has_api_key:
+        # Use custom header if provided, else default to X-API-Key
+        key = api_key_header if api_key_header else "X-API-Key"
+        value = api_key_value
+        headers[key] = value
+        logger.debug(f"MMSeqs2 server authentication: using API key in header '{key}'")
+    else:
+        logger.debug("MMSeqs2 server authentication: no credentials provided")
+    
+    logger.debug(f"Connecting to MMSeqs2 server at: {host_url}")
+    logger.debug(f"Using endpoint: {submission_endpoint}")
+    logger.debug(f"Pairing strategy: {pairing_strategy}")
+    logger.debug(f"Use environment databases: {use_env}")
+    logger.debug(f"Use filtering: {use_filter}")
 
     def submit(seqs, mode, N=101):
         n, query = N, ""
@@ -43,12 +82,15 @@ def run_mmseqs2(  # noqa: PLR0912, D103, C901, PLR0915
             try:
                 # https://requests.readthedocs.io/en/latest/user/advanced/#advanced
                 # "good practice to set connect timeouts to slightly larger than a multiple of 3"
+                logger.debug(f"Submitting MSA request to {host_url}/{submission_endpoint}")
                 res = requests.post(
                     f"{host_url}/{submission_endpoint}",
                     data={"q": query, "mode": mode},
                     timeout=6.02,
                     headers=headers,
+                    auth=auth,
                 )
+                logger.debug(f"MSA submission response status: {res.status_code}")
             except Exception as e:
                 error_count += 1
                 logger.warning(
@@ -74,9 +116,11 @@ def run_mmseqs2(  # noqa: PLR0912, D103, C901, PLR0915
         error_count = 0
         while True:
             try:
+                logger.debug(f"Checking MSA job status for ID: {ID}")
                 res = requests.get(
-                    f"{host_url}/ticket/{ID}", timeout=6.02, headers=headers
+                    f"{host_url}/ticket/{ID}", timeout=6.02, headers=headers, auth=auth
                 )
+                logger.debug(f"MSA status check response status: {res.status_code}")
             except Exception as e:
                 error_count += 1
                 logger.warning(
@@ -101,9 +145,11 @@ def run_mmseqs2(  # noqa: PLR0912, D103, C901, PLR0915
         error_count = 0
         while True:
             try:
+                logger.debug(f"Downloading MSA results for ID: {ID}")
                 res = requests.get(
-                    f"{host_url}/result/download/{ID}", timeout=6.02, headers=headers
+                    f"{host_url}/result/download/{ID}", timeout=6.02, headers=headers, auth=auth
                 )
+                logger.debug(f"MSA download response status: {res.status_code}")
             except Exception as e:
                 error_count += 1
                 logger.warning(
@@ -186,6 +232,7 @@ def run_mmseqs2(  # noqa: PLR0912, D103, C901, PLR0915
 
                 # wait for job to finish
                 ID, TIME = out["id"], 0
+                logger.debug(f"MSA job submitted successfully with ID: {ID}")
                 pbar.set_description(out["status"])
                 while out["status"] in ["UNKNOWN", "RUNNING", "PENDING"]:
                     t = 5 + random.randint(0, 5)
@@ -198,6 +245,7 @@ def run_mmseqs2(  # noqa: PLR0912, D103, C901, PLR0915
                         pbar.update(n=t)
 
                 if out["status"] == "COMPLETE":
+                    logger.debug(f"MSA job completed successfully for ID: {ID}")
                     if TIME < TIME_ESTIMATE:
                         pbar.update(n=(TIME_ESTIMATE - TIME))
                     REDO = False

--- a/src/boltz/data/msa/mmseqs2.py
+++ b/src/boltz/data/msa/mmseqs2.py
@@ -29,16 +29,13 @@ def run_mmseqs2(  # noqa: PLR0912, D103, C901, PLR0915
     msa_server_username: Optional[str] = None,
     msa_server_password: Optional[str] = None,
     auth_headers: Optional[Dict[str, str]] = None,
-    api_key_header: Optional[str] = None,
-    api_key_value: Optional[str] = None,
 ) -> tuple[list[str], list[str]]:
     submission_endpoint = "ticket/pair" if use_pairing else "ticket/msa"
 
     # Validate mutually exclusive authentication methods
     has_basic_auth = msa_server_username and msa_server_password
     has_header_auth = auth_headers is not None
-    has_api_key = api_key_value is not None
-    if has_basic_auth and (has_header_auth or has_api_key):
+    if has_basic_auth and (has_header_auth or auth_headers):
         raise ValueError(
             "Cannot use both basic authentication (username/password) and header/API key authentication. "
             "Please use only one authentication method."
@@ -56,12 +53,6 @@ def run_mmseqs2(  # noqa: PLR0912, D103, C901, PLR0915
     elif has_header_auth:
         headers.update(auth_headers)
         logger.debug("MMSeqs2 server authentication: using header-based authentication")
-    elif has_api_key:
-        # Use custom header if provided, else default to X-API-Key
-        key = api_key_header if api_key_header else "X-API-Key"
-        value = api_key_value
-        headers[key] = value
-        logger.debug(f"MMSeqs2 server authentication: using API key in header '{key}'")
     else:
         logger.debug("MMSeqs2 server authentication: no credentials provided")
     

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -490,8 +490,6 @@ def compute_msa(
         msa_server_username=msa_server_username,
         msa_server_password=msa_server_password,
         auth_headers=auth_headers,
-        api_key_header=api_key_header,
-        api_key_value=api_key_value,
     )
 
     for idx, name in enumerate(data):

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -460,7 +460,7 @@ def compute_msa(
             key: value
         }
         click.echo(f"Using API key authentication for MSA server (header: {key})")
-    elif msa_server_username:
+    elif msa_server_username and msa_server_password:
         click.echo("Using basic authentication for MSA server")
     else:
         click.echo("No authentication provided for MSA server")
@@ -490,6 +490,8 @@ def compute_msa(
         msa_server_username=msa_server_username,
         msa_server_password=msa_server_password,
         auth_headers=auth_headers,
+        api_key_header=api_key_header,
+        api_key_value=api_key_value,
     )
 
     for idx, name in enumerate(data):
@@ -1122,7 +1124,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
         click.echo(f"MSA server enabled: {msa_server_url}")
         if api_key_value:
             click.echo("MSA server authentication: using API key header")
-        elif msa_server_username:
+        elif msa_server_username and msa_server_password:
             click.echo("MSA server authentication: using basic auth")
         else:
             click.echo("MSA server authentication: no credentials provided")


### PR DESCRIPTION
## Summary

This PR adds security/authentication support for calling custom MSA servers in Boltz, enabling the use of both basic authentication and API token authentication when accessing protected MSA endpoints.

## Changes

- **MSA Server Authentication Support:**
  - Added support for **Basic Authentication** using `--msa_server_username` and `--msa_server_password` CLI options, or via the `BOLTZ_MSA_USERNAME` and `BOLTZ_MSA_PASSWORD` environment variables.
  - Added support for **API Key/Token Authentication** using `--api_key_header` and `--api_key_value` CLI options, or via the `MSA_API_KEY_VALUE` environment variable.
  - Ensured only one authentication method (basic or API key) can be used at a time, with clear error messages if both are provided.
  - Authentication is now properly passed to all MSA server requests.

- **Documentation:**
  - Updated the README to clearly explain both authentication methods, including usage examples and environment variable support.
  - Clarified that only one authentication method can be used at a time.

## Motivation

Many custom MSA servers require authentication for access. This PR enables Boltz users to securely provide credentials—either via basic auth or API token—when calling such servers, making Boltz compatible with a wider range of enterprise and protected deployments. Additionally if no authentication is required, everything works as before so it is simply optional.

See the "Authentication to MSA Server" section in the README for details and usage examples.
These changes make it easier for users to securely provide credentials for MSA server access, reduce confusion around environment variable names, and ensure the documentation matches the actual code behavior.

See the "Authentication to MSA Server" section in the README for details and usage examples.
s