### PR TITLE
fix: pass full BoltzSteeringParams to affinity prediction

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -1266,6 +1266,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
         steering_args.fk_steering = False
         steering_args.guidance_update = False
         steering_args.physical_guidance_update = False
+        steering_args.contact_guidance_update = False
         
         model_module = Boltz2.load_from_checkpoint(
             affinity_checkpoint,


### PR DESCRIPTION
With the new recent updates, affinity prediction fails, when using the `force` option on pocket constraints (probably also for contact constraints and templates).

E.g.

```
File ".../lib/python3.11/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.11/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../boltz/src/boltz/model/models/boltz2.py", line 533, in forward
    struct_out = self.structure_module.sample(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../boltz/src/boltz/model/modules/diffusionv2.py", line 306, in sample
    or steering_args["physical_guidance_update"]
       ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'physical_guidance_update'
```

This PR introduces a quick fix by passing a full `BoltzSteeringParams` object (as dict) while keeping the previous default settings.

Should fix #469