### PR TITLE
Add basic version reporting

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -33,6 +33,8 @@ from boltz.data.write.writer import BoltzAffinityWriter, BoltzWriter
 from boltz.model.models.boltz1 import Boltz1
 from boltz.model.models.boltz2 import Boltz2
 
+from boltz import __version__
+
 CCD_URL = "https://huggingface.co/boltz-community/boltz-1/resolve/main/ccd.pkl"
 MOL_URL = "https://huggingface.co/boltz-community/boltz-2/resolve/main/mols.tar"
 
@@ -807,10 +809,10 @@ def process_inputs(
     manifest.dump(out_dir / "processed" / "manifest.json")
 
 
-@click.group()
+@click.group(help=f"Boltz v{__version__}")
+@click.version_option(__version__)
 def cli() -> None:
-    """Boltz."""
-    return
+    pass
 
 
 @cli.command()

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -812,7 +812,7 @@ def process_inputs(
 @click.group(help=f"Boltz v{__version__}")
 @click.version_option(__version__)
 def cli() -> None:
-    pass
+    click.echo(f"Boltz v{__version__}")
 
 
 @cli.command()


### PR DESCRIPTION
This PR adds basic version reporting:

- Adds ```click.version_option``` to expose a ```--version``` command
- Includes the Boltz version in the CLI help header
- Prints the version at the start of every command

These changes were originally part of PR #461, but I’ve separated them here for clarity and better reviewability.
Happy to make any adjustments!
