### PR TITLE
Minor simplification of Diffusion Loss

### DIFF
--- a/src/boltz/model/modules/diffusionv2.py
+++ b/src/boltz/model/modules/diffusionv2.py
@@ -585,7 +585,6 @@ class AtomDiffusion(Module):
         )
 
         return {
-            "noised_atom_coords": noised_atom_coords,
             "denoised_atom_coords": denoised_atom_coords,
             "sigmas": sigmas,
             "aligned_true_atom_coords": atom_coords,
@@ -603,7 +602,6 @@ class AtomDiffusion(Module):
     ):
         with torch.autocast("cuda", enabled=False):
             denoised_atom_coords = out_dict["denoised_atom_coords"].float()
-            noised_atom_coords = out_dict["noised_atom_coords"].float()
             sigmas = out_dict["sigmas"].float()
 
             resolved_atom_mask_uni = feats["atom_resolved_mask"].float()
@@ -616,7 +614,7 @@ class AtomDiffusion(Module):
                 multiplicity, 0
             )
 
-            align_weights = noised_atom_coords.new_ones(noised_atom_coords.shape[:2])
+            align_weights = denoised_atom_coords.new_ones(denoised_atom_coords.shape[:2])
             atom_type = (
                 torch.bmm(
                     feats["atom_to_token"].float(),


### PR DESCRIPTION
Diffusion loss contains `noised_atom_coords` only for the shape. The shape can actually be extracted out of the `denoised_atom_coords` as they are the same shape.

Another potential simplification/modification is to use `resolved_atom_mask` in the weighted_rigid_align
```python
# instead of
atom_coords_aligned_ground_truth = weighted_rigid_align(
    atom_coords.detach(),
    denoised_atom_coords.detach(),
    align_weights.detach(),
    mask=feats["atom_resolved_mask"]
    .float()
    .repeat_interleave(multiplicity, 0)
    .detach(),
)

# we can do
atom_coords_aligned_ground_truth = weighted_rigid_align(
    atom_coords.detach(),
    denoised_atom_coords.detach(),
    align_weights.detach(),
    mask=resolved_atom_mask.detach(),
)
```
I haven't made this change because there is a chance that we do not want the `filter_by_plddt` to modify this. Would be happy to also add this.