### PR TITLE
Fix help message in --use_potentials flag

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -967,7 +967,7 @@ def cli() -> None:
 @click.option(
     "--use_potentials",
     is_flag=True,
-    help="Whether to not use potentials for steering. Default is False.",
+    help="Whether to use potentials for steering. Default is False.",
 )
 @click.option(
     "--model",


### PR DESCRIPTION
The help message for the `--use_potentials` flag is incorrect. 