### PR TITLE
Removing content-type from authentication headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There are two main predictions in the affinity output: `affinity_pred_value` and
 
 ## Authentication to MSA Server
 
-When using the `--use_msa_server` option with a server that requires authentication, you can provide credentials in one of two ways. More information is available in our [prediction instructions](docs/prediction.md).
+When using the `--use_msa_server` option with a server that requires authentication, you can provide credentials in one of two ways. More information is available in our [prediction instructions](docs/prediction.md#authentication-to-msa-server).
  
 ## Evaluation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "boltz"
-version = "2.2.0"
+version = "2.2.1"
 requires-python = ">=3.10,<3.13"
 description = "Boltz"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "boltz"
-version = "2.2.1"
+version = "2.2.0"
 requires-python = ">=3.10,<3.13"
 description = "Boltz"
 readme = "README.md"

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -457,7 +457,6 @@ def compute_msa(
         key = api_key_header if api_key_header else "X-API-Key"
         value = api_key_value
         auth_headers = {
-            "Content-Type": "application/json",
             key: value
         }
         click.echo(f"Using API key authentication for MSA server (header: {key})")


### PR DESCRIPTION
**Motivation**

This MR removes the `Content-Type` key from the authentication headers. Some MSA servers actually expect different content type, and authentication should not try to change this type. 

Additionally, fixed the links from the main README.md file to the authentication instructions. 

