### PR TITLE
Minor guidance_update renaming cleanup

### DIFF
--- a/scripts/train/configs/confidence.yaml
+++ b/scripts/train/configs/confidence.yaml
@@ -197,5 +197,5 @@ model:
     num_particles: 3
     fk_lambda: 4.0
     fk_resampling_interval: 3
-    guidance_update: False
+    physical_guidance_update: False
     num_gd_steps: 16 

--- a/scripts/train/configs/full.yaml
+++ b/scripts/train/configs/full.yaml
@@ -196,5 +196,5 @@ model:
     num_particles: 3
     fk_lambda: 4.0
     fk_resampling_interval: 3
-    guidance_update: False
+    physical_guidance_update: False
     num_gd_steps: 16 

--- a/scripts/train/configs/structure.yaml
+++ b/scripts/train/configs/structure.yaml
@@ -190,5 +190,5 @@ model:
     num_particles: 3
     fk_lambda: 4.0
     fk_resampling_interval: 3
-    guidance_update: False
+    physical_guidance_update: False
     num_gd_steps: 16 

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -1385,7 +1385,6 @@ def predict(  # noqa: C901, PLR0915, PLR0912
 
         steering_args = BoltzSteeringParams()
         steering_args.fk_steering = False
-        steering_args.guidance_update = False
         steering_args.physical_guidance_update = False
         steering_args.contact_guidance_update = False
         


### PR DESCRIPTION
`guidance_update` was renamed to `physical_guidance_update` to disambiguate from other guiding potentials.
A couple of instances of the old name remain in the main branch