### PR TITLE
bugfix: NoneType not iterable when inference_pocket_constraints is None

### DIFF
--- a/src/boltz/data/feature/featurizerv2.py
+++ b/src/boltz/data/feature/featurizerv2.py
@@ -2057,7 +2057,9 @@ def process_chain_feature_constraints(data: Tokenized) -> dict[str, Tensor]:
 
 
 def process_contact_feature_constraints(
-    data, inference_pocket_constraints, inference_contact_constraints
+    data: Tokenized,
+    inference_pocket_constraints: list[tuple[int, list[tuple[int, int]], float]],
+    inference_contact_constraints: list[tuple[tuple[int, int], tuple[int, int], float]],
 ):
     token_data = data.tokens
     union_idx = 0
@@ -2332,7 +2334,9 @@ class Boltz2Featurizer:
             residue_constraint_features = process_residue_constraint_features(data)
             chain_constraint_features = process_chain_feature_constraints(data)
             contact_constraint_features = process_contact_feature_constraints(
-                data, inference_pocket_constraints, inference_contact_constraints
+                data=data,
+                inference_pocket_constraints=inference_pocket_constraints if inference_pocket_constraints else [],
+                inference_contact_constraints=inference_contact_constraints if inference_contact_constraints else [],
             )
 
         return {


### PR DESCRIPTION
`Featurizerv2.process_contact_feature_constraints` raises:<br>`TypeError: 'NoneType' object is not iterable` <br>when either `inference_pocket_constraints=None` or `inference_contact_constraints=None` and `compute_constraint_features=True`.

Proposed solution is the minimal diff (also added explicit typing to the function to show that the constraint arguments are not `Optional` in this function (unlike above in the file))