### PR TITLE
Look up MSA files relative to input fasta/yaml

### DIFF
--- a/src/boltz/data/parse/fasta.py
+++ b/src/boltz/data/parse/fasta.py
@@ -134,5 +134,4 @@ def parse_fasta(  # noqa: C901, PLR0912
         "version": 1,
     }
 
-    name = path.stem
-    return parse_boltz_schema(name, data, ccd, mol_dir, boltz2)
+    return parse_boltz_schema(path, data, ccd, mol_dir, boltz2)

--- a/src/boltz/data/parse/schema.py
+++ b/src/boltz/data/parse/schema.py
@@ -937,7 +937,7 @@ def token_spec_to_ids(
 
 
 def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
-    name: str,
+    path: Path,
     schema: dict,
     ccd: Mapping[str, Mol],
     mol_dir: Optional[Path] = None,
@@ -983,8 +983,8 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
 
     Parameters
     ----------
-    name : str
-        A name for the input.
+    path : Path
+        Path to the input file.
     schema : dict
         The input schema.
     components : dict
@@ -1000,6 +1000,7 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
         The parsed target.
 
     """
+    name, parent = path.stem, path.parent
     # Assert version 1
     version = schema.get("version", 1)
     if version != 1:
@@ -1110,12 +1111,16 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
             msa = items[0][entity_type].get("msa", 0)
             if (msa is None) or (msa == ""):
                 msa = 0
+            if msa != 0:
+                msa = str((parent / msa).resolve())
 
             # Check if all MSAs are the same within the same entity
             for item in items:
                 item_msa = item[entity_type].get("msa", 0)
                 if (item_msa is None) or (item_msa == ""):
                     item_msa = 0
+                if item_msa != 0:
+                    item_msa = str((parent / item_msa).resolve())
 
                 if item_msa != msa:
                     msg = "All proteins with the same sequence must share the same MSA!"

--- a/src/boltz/data/parse/yaml.py
+++ b/src/boltz/data/parse/yaml.py
@@ -64,5 +64,4 @@ def parse_yaml(
     with path.open("r") as file:
         data = yaml.safe_load(file)
 
-    name = path.stem
-    return parse_boltz_schema(name, data, ccd, mol_dir, boltz2)
+    return parse_boltz_schema(path, data, ccd, mol_dir, boltz2)


### PR DESCRIPTION
At the moment, relative MSA lookups seem to work relative to the current working directory. I would like to propose a change in behavior where the MSA file is looked up relative to the directory of the input file. In this way, I do not need to update the input fasta/yaml if I run the model from a different directory. For me, this would make data exchange much easier, as I only need to preserve my directory layout for the exchange. 

I understand that this is a change in the user interface and that there might be good reasons for the current behavior. As the code changes were rather minimal, I decided to go ahead an just open a PR. At the same time, I understand if further discussions are necessary. I am also completely open to the conclusion that this change proposal should be disregarded.

# Example

 Directory structure 
```bash
data
├── fastas
│   └── relative.fasta
├── msas
│   └── 1e73__1__2.A__2.I.a3m
└── yamls
    └── relative.yaml

```

fasta input
```
>A|protein|../msas/1e73__1__2.A__2.I.a3m
DEEITCQENLPFTCGNTDALNSSSFSSDFIFGVASSAYQIEGTIGRGLNIWDGFTHRYPNKSGPDHGNGDTTCDSFSYWQKDIDVLDELNATGYRFSIAWSRIIPRGKRSRGVNEKGIDYYHGLISGLIKKGITPFVTLFHWDLPQTLQDEYEGFLDPQIIDDFKDYADLCFEEFGDSVKYWLTINQLYSVPTRGYGSALDAPGRCSPTVDPSCYAGNSSTEPYIVAHHQLLAHAKVVDLYRKNYTHQGGKIGPTMITRWFLPYNDTDRHSIAATERMKEFFLGWFMGPLTNGTYPQIMIDTVGERLPSFSPEESNLVKGSYDFLGLNYYFTQYAQPSPNPVNSTNHTAMMDAGAKLTYINASGHYIGPLFEKDKADSTDNIYYYPKGIYSVMDYFKNKYYNPLIYVTENGISTPGDENRNQSMLDYTRIDYLCSHLCFLNKVIKEKDVNVKGYLAWALGDNYEFNKGFTVRFGLSYIDWNNVTDRDLKKSGQWYQSFISP
>B|smiles
CC(=O)N[C@H]1CO[C@H](CO)[C@@H](O)[C@@H]1O
```

yaml input
```yaml
version: 1
sequences:
  - protein:
      id: A
      sequence: DEEITCQENLPFTCGNTDALNSSSFSSDFIFGVASSAYQIEGTIGRGLNIWDGFTHRYPNKSGPDHGNGDTTCDSFSYWQKDIDVLDELNATGYRFSIAWSRIIPRGKRSRGVNEKGIDYYHGLISGLIKKGITPFVTLFHWDLPQTLQDEYEGFLDPQIIDDFKDYADLCFEEFGDSVKYWLTINQLYSVPTRGYGSALDAPGRCSPTVDPSCYAGNSSTEPYIVAHHQLLAHAKVVDLYRKNYTHQGGKIGPTMITRWFLPYNDTDRHSIAATERMKEFFLGWFMGPLTNGTYPQIMIDTVGERLPSFSPEESNLVKGSYDFLGLNYYFTQYAQPSPNPVNSTNHTAMMDAGAKLTYINASGHYIGPLFEKDKADSTDNIYYYPKGIYSVMDYFKNKYYNPLIYVTENGISTPGDENRNQSMLDYTRIDYLCSHLCFLNKVIKEKDVNVKGYLAWALGDNYEFNKGFTVRFGLSYIDWNNVTDRDLKKSGQWYQSFISP
      msa: ../msas/1e73__1__2.A__2.I.a3m
  - ligand:
      id: B
      smiles: CC(=O)N[C@H]1CO[C@H](CO)[C@@H](O)[C@@H]1O
```

Run command
```bash
boltz predict /data/fastas/relative.fasta
```
or
```bash
boltz predict /data/yamls/relative.yaml
```

I am happy to provide the MSA file. It seems to be too large to attach to the post.

## Expected behavior

The prediction should work.

## Observed behavior

```bash
Traceback (most recent call last):
  File "/xxx/xxx/boltz/src/boltz/main.py", line 608, in process_input
    raise FileNotFoundError(msg)  # noqa: TRY301
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: MSA file ../msas/1e73__1__2.A__2.I.a3m not found.
Failed to process /data/boltz_msa_example/yamls/relative.yaml. Skipping. Error: MSA file ../msas/1e73__1__2.A__2.I.a3m not found..
```