### PR TITLE
Allow template to have indel compared to the original sequence

### DIFF
--- a/src/boltz/data/feature/featurizerv2.py
+++ b/src/boltz/data/feature/featurizerv2.py
@@ -1800,6 +1800,7 @@ def process_template_features(
 
         for template in templates:
             offset = template.template_st - template.query_st
+            query_templated_segments = set(range(template.query_st, template.query_en))
 
             # Get query and template tokens to map residues
             query_tokens = data.tokens
@@ -1810,7 +1811,7 @@ def process_template_features(
             # Get the template tokens at the query residues
             chain_id = tmpl_chain_name_to_asym_id[template.template_chain]
             toks = template_tokens[template_tokens["asym_id"] == chain_id]
-            toks = [t for t in toks if t["res_idx"] - offset in q_indices]
+            toks = [t for t in toks if t["res_idx"] - offset in query_templated_segments]
             for t in toks:
                 q_idx = q_indices[t["res_idx"] - offset]
                 row_tokens.append(


### PR DESCRIPTION
Thank you for providing the great software. While reading the source code and tweaking the templating mechanism for my own purpose, I found that the current boltz has the problem (1) using Bio.Align and (2) featurizing the template. 

First problem is that the alignment to the base structure (cif or recently pdb file) is forced to be gapless. 
https://github.com/jwohlwend/boltz/blob/c9b6af1f13dd22d7ad394131928f0772ec37a82f/src/boltz/data/parse/schema.py#L524-L527

The parameters `open_gap_score` and `extend_gap_score` has an extreme penalty and do not allow the gap.

Furthermore, the program iterates over the alignment object, which results in looping _for each  possible alignment_ in Biopython and therefore is not suitable to get the _best_ alignment.
https://github.com/jwohlwend/boltz/blob/c9b6af1f13dd22d7ad394131928f0772ec37a82f/src/boltz/data/parse/schema.py#L530

Additionally, featurizer do not correctly convert the token into the template map. The current code worked when the alignment was only a single chunk (which was automatically satisfied because of the gaplessness though)
https://github.com/jwohlwend/boltz/blob/c9b6af1f13dd22d7ad394131928f0772ec37a82f/src/boltz/data/feature/featurizerv2.py#L1802

As a result, template structures currently do not allow indel to appear, significantly hampers the capability of the templating.

This PR aims to fix these problems. 

Some concerns remain about the template:
1. I haven't dug into the code whether this change requires you to retrain the template related weights (?). From my quick glance it seems fine, but I'd like to hear the opinion from experts.
2. When using the template with the low identity, `Bio.Align.PairwiseAlignment` may not be able to properly align two sequences. As a reference, AF3 circumvents the problem by  `hmmbuild` and `hmmsearch` and directly feeds the output alignment. We may need a similar input to directly specify the feature-template matching.
3. When cif file does not contain proper full sequence (e.g. converting pdb without SEQRES by maxit), missing loops may result in an improper template. For example, when `ACDEFG---HIKLMN` where `---` is a missing loop, and input sequence is `ACDEFGH`, the program may try to align final residue and results in a skewed structure (especially if using `force: true`). But I am not sure what should be the "correct" behavior here.


