### PR TITLE
Pad cyclic_period to ensure tensors passed to forward have a static size

### DIFF
--- a/src/boltz/data/feature/featurizer.py
+++ b/src/boltz/data/feature/featurizer.py
@@ -644,6 +644,7 @@ def process_token_features(
             resolved_mask = pad_dim(resolved_mask, 0, pad_len)
             disto_mask = pad_dim(disto_mask, 0, pad_len)
             pocket_feature = pad_dim(pocket_feature, 0, pad_len)
+            cyclic_period = pad_dim(cyclic_period, 0, pad_len)
 
     token_features = {
         "token_index": token_index,


### PR DESCRIPTION
It looks like `cyclic_period` was accidentally omitted from padding logic, which leads to dynamic tensor shapes when invoking the model.