### PR TITLE
Only consider standard residues in consecutive CA filter

### DIFF
--- a/src/boltz/data/filter/static/polymer.py
+++ b/src/boltz/data/filter/static/polymer.py
@@ -141,6 +141,7 @@ class ConsecutiveCA(StaticFilter):
             res_start = chain["res_idx"]
             res_end = res_start + chain["res_num"]
             residues = structure.residues[res_start:res_end]
+            residues = residues[np.where(residues["is_standard"])]
 
             # Get c-alphas
             ca_ids = residues["atom_center"]


### PR DESCRIPTION
The consecutive CA filter marks a protein chain as invalid if it has two consecutive residues that are too far apart. I have CIF files where a few zinc and calcium ions are included in the protein chain. Since the ions are far apart, this chain would previously have been marked invalid by the filter. After this small change, the ions are ignored by the filter and the protein chain is marked as valid during processing.