### PR TITLE
Fix #583 parsing .csv MSA files removes paired sequences.

### DIFF
--- a/src/boltz/data/parse/csv.py
+++ b/src/boltz/data/parse/csv.py
@@ -57,7 +57,8 @@ def parse_csv(
         str_seq = line.replace("-", "").upper()
         if str_seq not in visited:
             visited.add(str_seq)
-        else:
+        elif taxonomy_id == -1:
+            # Omit duplicate unpaired sequences
             continue
 
         # Process sequence


### PR DESCRIPTION
Fix parsing .csv files to not remove duplicate sequences that are paired, issue #583.