### PR TITLE
use mol cache when tar archive missing

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -207,7 +207,7 @@ def download_boltz2(cache: Path) -> None:
     # Download CCD
     mols = cache / "mols"
     tar_mols = cache / "mols.tar"
-    if not tar_mols.exists():
+    if not (mols.exists() or tar_mols.exists()):
         click.echo(
             f"Downloading the CCD data to {tar_mols}. "
             "This may take a bit of time. You may change the cache directory "


### PR DESCRIPTION
The current cache expects to see the `mol.tar` archive rather than the `mol` directory. This means that the download is triggered even if the `mol` directory is in the cache.

This is a small change to check for either `mol` or `mol.tar` before re-initiating the download.