### PR TITLE
docs: add Boltz-DAP link for multi-GPU inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ We welcome external contributions and are eager to engage with the community. Co
 
 On recent NVIDIA GPUs, Boltz leverages the acceleration provided by [NVIDIA  cuEquivariance](https://developer.nvidia.com/cuequivariance) kernels. Boltz also runs on Tenstorrent hardware thanks to a [fork](https://github.com/moritztng/tt-boltz) by Moritz Thüning.
 
+Community projects for scaling Boltz across multiple GPUs:
+
+- [Fold-CP (Context Parallelism)](https://github.com/jwohlwend/boltz/pull/658) — 2D CP mesh for distributed inference/training.
+- [Boltz-DAP (Distributed Axial Parallelism)](https://github.com/coqylight/boltz_dap) — shards the pair representation across GPUs to reduce per-GPU memory and avoid OOM on large complexes (inference wrapper; no Boltz source modifications).
+
 ## License
 
 Our model and code are released under MIT License, and can be freely used for both academic and commercial purposes.

--- a/README.md
+++ b/README.md
@@ -78,9 +78,8 @@ We welcome external contributions and are eager to engage with the community. Co
 
 On recent NVIDIA GPUs, Boltz leverages the acceleration provided by [NVIDIA  cuEquivariance](https://developer.nvidia.com/cuequivariance) kernels. Boltz also runs on Tenstorrent hardware thanks to a [fork](https://github.com/moritztng/tt-boltz) by Moritz Thüning.
 
-Community projects for scaling Boltz across multiple GPUs:
+Community project for scaling Boltz across multiple GPUs:
 
-- [Fold-CP (Context Parallelism)](https://github.com/jwohlwend/boltz/pull/658) — 2D CP mesh for distributed inference/training.
 - [Boltz-DAP (Distributed Axial Parallelism)](https://github.com/coqylight/boltz_dap) — shards the pair representation across GPUs to reduce per-GPU memory and avoid OOM on large complexes (inference wrapper; no Boltz source modifications).
 
 ## License


### PR DESCRIPTION
## Summary
- Add a short community-project note in README linking to Boltz-DAP.

## Why
- Users running large complexes often look for multi-GPU options.
- This improves discoverability without modifying Boltz core code.

## Link
- Boltz-DAP: https://github.com/coqylight/boltz_dap