### PR TITLE
fix: validate checkpoint files before loading and surface actionable errors for empty/corrupt weights

### DIFF
--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -345,3 +345,40 @@ N[C@@H](Cc1ccc(O)cc1)C(=O)O
 ## Troubleshooting
 
  - When running on old NVIDIA GPUs, you may encounter an error related to the `cuequivariance` library. In this case, you should run the model with the `--no_kernels` flag, which will disable the use of the `cuequivariance` library and allow the model to run without it. This may result in slightly lower performance, but it will allow you to run the model on older hardware.
+## Troubleshooting
+
+### `Aborted!` or an unpickling error during prediction
+
+**Symptom**
+
+`boltz predict` exits immediately after "Running structure prediction for N
+inputs." with a bare `Aborted!` or a long Python traceback ending somewhere
+inside PyTorch Lightning's checkpoint loader.
+
+**Likely cause**
+
+One of the auto-downloaded checkpoint files (`boltz2_conf.ckpt`,
+`boltz2_aff.ckpt`, or `boltz1_conf.ckpt`) is empty or truncated — a common
+result of a network interruption during the first run.  Because the file
+already exists, subsequent runs skip the download and pass the bad path
+directly to the model loader.
+
+**Fix**
+
+Delete the suspect file and rerun. Boltz will re-download it automatically.
+
+```bash
+# Default cache location is ~/.boltz
+rm ~/.boltz/boltz2_conf.ckpt      # structure weights
+rm ~/.boltz/boltz2_aff.ckpt       # affinity weights   (if needed)
+rm ~/.boltz/boltz1_conf.ckpt      # Boltz-1 weights    (if using --model boltz1)
+
+boltz predict <your_input> ...
+```
+
+If you set a custom cache via `--cache` or `$BOLTZ_CACHE`, replace `~/.boltz`
+with that path.
+
+> **Note:** From v2.2.2 onwards, Boltz validates every checkpoint file
+> immediately after download and again before loading, so a corrupted file
+> will surface as a clear error message rather than a silent `Aborted!`.

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -51,6 +51,11 @@ BOLTZ2_AFFINITY_URL_WITH_FALLBACK = [
     "https://huggingface.co/boltz-community/boltz-2/resolve/main/boltz2_aff.ckpt",
 ]
 
+# Minimum expected checkpoint size in bytes (1 MB).
+# A legitimate Boltz checkpoint is hundreds of MB; anything smaller is almost
+# certainly the result of an interrupted or zero-byte download.
+_MIN_CHECKPOINT_SIZE_BYTES = 1 * 1024 * 1024  # 1 MB
+
 
 @dataclass
 class BoltzProcessedInput:
@@ -157,6 +162,49 @@ class BoltzSteeringParams:
     num_gd_steps: int = 20
 
 
+def validate_checkpoint(path: Path, label: str = "Checkpoint") -> None:
+    """Validate that a checkpoint file exists and appears intact.
+
+    This is a lightweight pre-flight check — it catches the common failure mode
+    where ``urllib.request.urlretrieve`` leaves a zero-byte or truncated file
+    after a network interruption, which would otherwise surface as a cryptic
+    ``Aborted!`` or unpickling error deep inside PyTorch Lightning.
+
+    Parameters
+    ----------
+    path : Path
+        Path to the checkpoint file.
+    label : str, optional
+        Human-readable label used in error messages (e.g. ``"Boltz-2 checkpoint"``).
+
+    Raises
+    ------
+    click.ClickException
+        If the file is missing, unreadable, empty, or below
+        ``_MIN_CHECKPOINT_SIZE_BYTES``.
+
+    """
+    if not path.exists():
+        msg = (
+            f"{label} not found: {path}. "
+            "Delete the file if it exists and rerun to trigger a fresh download."
+        )
+        raise click.ClickException(msg)
+    try:
+        size = path.stat().st_size
+    except OSError as e:
+        msg = f"{label} is not readable: {path}. Error: {e}"
+        raise click.ClickException(msg) from e
+    if size < _MIN_CHECKPOINT_SIZE_BYTES:
+        msg = (
+            f"{label} appears empty or corrupted: {path} "
+            f"({size:,} bytes, expected at least "
+            f"{_MIN_CHECKPOINT_SIZE_BYTES:,} bytes). "
+            "Delete the file and rerun to trigger a fresh download."
+        )
+        raise click.ClickException(msg)
+
+
 @rank_zero_only
 def download_boltz1(cache: Path) -> None:
     """Download all the required data.
@@ -192,6 +240,7 @@ def download_boltz1(cache: Path) -> None:
                     msg = f"Failed to download model from all URLs. Last error: {e}"
                     raise RuntimeError(msg) from e
                 continue
+    validate_checkpoint(model, label="Boltz-1 checkpoint")
 
 
 @rank_zero_only
@@ -239,6 +288,7 @@ def download_boltz2(cache: Path) -> None:
                     msg = f"Failed to download model from all URLs. Last error: {e}"
                     raise RuntimeError(msg) from e
                 continue
+    validate_checkpoint(model, label="Boltz-2 checkpoint")
 
     # Download affinity model
     affinity_model = cache / "boltz2_aff.ckpt"
@@ -256,6 +306,7 @@ def download_boltz2(cache: Path) -> None:
                     msg = f"Failed to download model from all URLs. Last error: {e}"
                     raise RuntimeError(msg) from e
                 continue
+    validate_checkpoint(affinity_model, label="Boltz-2 affinity checkpoint")
 
 
 def get_cache_path() -> str:
@@ -1296,6 +1347,14 @@ def predict(  # noqa: C901, PLR0915, PLR0912
             else:
                 checkpoint = cache / "boltz1_conf.ckpt"
 
+        # Validate checkpoint before attempting to load it, so that a
+        # corrupted or empty file (e.g. from an interrupted download) surfaces
+        # as a clear, actionable error rather than a cryptic Aborted! message.
+        validate_checkpoint(
+            Path(checkpoint),
+            label=f"{'Boltz-2' if model == 'boltz2' else 'Boltz-1'} checkpoint",
+        )
+
         predict_args = {
             "recycling_steps": recycling_steps,
             "sampling_steps": sampling_steps,
@@ -1382,6 +1441,11 @@ def predict(  # noqa: C901, PLR0915, PLR0912
         # Load affinity model
         if affinity_checkpoint is None:
             affinity_checkpoint = cache / "boltz2_aff.ckpt"
+
+        validate_checkpoint(
+            Path(affinity_checkpoint),
+            label="Boltz-2 affinity checkpoint",
+        )
 
         steering_args = BoltzSteeringParams()
         steering_args.fk_steering = False


### PR DESCRIPTION
# PR: Validate checkpoint files before loading and surface actionable errors for empty/corrupt weights

Closes #664

---

## Problem

When `urllib.request.urlretrieve` is interrupted mid-download (network drop, disk full, SIGINT, etc.) it leaves a **zero-byte or truncated `.ckpt` file** on disk and does not raise an exception.  On the next `boltz predict` run:

1. The file already exists → the download is skipped.
2. The corrupted path is passed to `load_from_checkpoint`.
3. PyTorch Lightning aborts deep in its unpickling stack with a bare`Aborted!` and no indication of which file is at fault or how to fix it.

Issue #664 documents this exact failure mode and explicitly requests:
- size validation after download
- a clear error before `load_from_checkpoint`
- a docs note explaining the fix

---

## Changes

### `src/boltz/main.py`

**1. New constant**

```python
_MIN_CHECKPOINT_SIZE_BYTES = 1 * 1024 * 1024  # 1 MB
```

Real Boltz checkpoints are hundreds of MB.  1 MB catches every practical failure (empty file, tiny partial download, accidental placeholder) with no risk of false positives on legitimate user-supplied checkpoints.

**2. New helper: `validate_checkpoint(path, label)`**

```python
def validate_checkpoint(path: Path, label: str = "Checkpoint") -> None:
    """Validate that a checkpoint file exists and appears intact."""
    if not path.exists():
        raise click.ClickException(
            f"{label} not found: {path}. "
            "Delete the file if it exists and rerun to trigger a fresh download."
        )
    try:
        size = path.stat().st_size
    except OSError as e:
        raise click.ClickException(
            f"{label} is not readable: {path}. Error: {e}"
        ) from e
    if size < _MIN_CHECKPOINT_SIZE_BYTES:
        raise click.ClickException(
            f"{label} appears empty or corrupted: {path} "
            f"({size:,} bytes, expected at least {_MIN_CHECKPOINT_SIZE_BYTES:,} bytes). "
            "Delete the file and rerun to trigger a fresh download."
        )
```

Uses `click.ClickException` so Click prints `Error: …` cleanly with no traceback, matching the style of every other user-facing error in this file.

**3. Post-download validation** (`download_boltz1`, `download_boltz2`)

One call appended after each `urlretrieve` block:

```python
validate_checkpoint(model, label="Boltz-1 checkpoint")
validate_checkpoint(model, label="Boltz-2 checkpoint")
validate_checkpoint(affinity_model, label="Boltz-2 affinity checkpoint")
```

This means a bad write fails *at download time*, not minutes later when the
model starts loading.

**4. Pre-flight validation in `predict()`** — two call sites

Before the structure model load:
```python
# Validate checkpoint before attempting to load it, so that a
# corrupted or empty file (e.g. from an interrupted download) surfaces
# as a clear, actionable error rather than a cryptic Aborted! message.
validate_checkpoint(
    Path(checkpoint),
    label=f"{'Boltz-2' if model == 'boltz2' else 'Boltz-1'} checkpoint",
)
```

Before the affinity model load:
```python
validate_checkpoint(
    Path(affinity_checkpoint),
    label="Boltz-2 affinity checkpoint",
)
```

This matters for `--checkpoint` / `--affinity_checkpoint` paths too:
`click.Path(exists=True)` only checks existence, not size.

### `docs/prediction.md`

Adds a **Troubleshooting** section at the end of the file with:
- the symptom (`Aborted!`)
- the root cause (interrupted download)
- the one-line fix (`rm ~/.boltz/boltz2_conf.ckpt && boltz predict …`)

---

## Before / After

```
# Before (empty checkpoint file, no useful output):
$ truncate -s 0 ~/.boltz/boltz2_conf.ckpt
$ boltz predict test.yaml
...
Running structure prediction for 1 input.
Aborted!

# After:
$ truncate -s 0 ~/.boltz/boltz2_conf.ckpt
$ boltz predict test.yaml
...
Error: Boltz-2 checkpoint appears empty or corrupted:
/home/user/.boltz/boltz2_conf.ckpt (0 bytes, expected at least
1,048,576 bytes). Delete the file and rerun to trigger a fresh download.
```

---

## Design notes

- **No torch.load probe** — a full pickle-deserialization check would take the
  same time as loading the model.  The size floor is fast, zero-dependency, and
  catches all reported cases in #664.
- **No change to model logic** — all changes are in the CLI layer.
- **Backward compatible** — users passing valid `--checkpoint` paths are
  unaffected.  The only new behaviour is a clear error where there was
  previously a silent crash.
- **`click.ClickException` not `RuntimeError`** — keeps the error output
  consistent with the rest of the CLI and suppresses the traceback that
  confused users in #664.

---

## Testing

To reproduce the bug and verify the fix:

```bash
# Setup
pip install boltz -U
boltz predict some_input.yaml  # run once to populate cache

# Simulate a corrupt checkpoint
truncate -s 0 ~/.boltz/boltz2_conf.ckpt

# Without this PR: Aborted!
# With this PR:
boltz predict some_input.yaml
# Error: Boltz-2 checkpoint appears empty or corrupted: ...
```

To test the post-download guard specifically, the download URLs would need to be mocked to return an empty body - that is left as a follow-up unit test if the project adopts a test for the download path.