### PR TITLE
fix: force float32 precision on CPU to prevent distorted structures

### DIFF
--- a/src/boltz/model/models/boltz2.py
+++ b/src/boltz/model/models/boltz2.py
@@ -35,6 +35,7 @@ from boltz.model.modules.trunkv2 import (
 )
 from boltz.model.optim.ema import EMA
 from boltz.model.optim.scheduler import AlphaFoldLRScheduler
+from boltz.model.modules.utils import autocast_device_type
 
 
 class Boltz2(LightningModule):
@@ -529,7 +530,7 @@ class Boltz2(LightningModule):
                     "token_trans_bias": token_trans_bias,
                 }
 
-                with torch.autocast("cuda", enabled=False):
+                with torch.autocast(autocast_device_type(s.device.type), enabled=False):
                     struct_out = self.structure_module.sample(
                         s_trunk=s.float(),
                         s_inputs=s_inputs.float(),
@@ -568,7 +569,7 @@ class Boltz2(LightningModule):
                 feats["coords"] = atom_coords  # (multiplicity, L, 3)
                 assert len(feats["coords"].shape) == 3
 
-                with torch.autocast("cuda", enabled=False):
+                with torch.autocast(autocast_device_type(s.device.type), enabled=False):
                     struct_out = self.structure_module(
                         s_trunk=s.float(),
                         s_inputs=s_inputs.float(),
@@ -625,7 +626,7 @@ class Boltz2(LightningModule):
             ]
             s_inputs = self.input_embedder(feats, affinity=True)
 
-            with torch.autocast("cuda", enabled=False):
+            with torch.autocast(autocast_device_type(s.device.type), enabled=False):
                 if self.affinity_ensemble:
                     dict_out_affinity1 = self.affinity_module1(
                         s_inputs=s_inputs.detach(),

--- a/src/boltz/model/modules/utils.py
+++ b/src/boltz/model/modules/utils.py
@@ -13,6 +13,18 @@ from torch.types import Device
 
 LinearNoBias = partial(Linear, bias=False)
 
+def autocast_device_type(device_type: str) -> str:
+    """Return a device_type string accepted by ``torch.autocast``.
+
+    When autocast is used with ``enabled=False`` (to disable autocasting),
+    PyTorch still validates the device_type. MPS was not a valid autocast
+    device type until PyTorch 2.4. Since ``enabled=False`` is a no-op, we
+    fall back to ``"cpu"``, which is always accepted.
+    """
+    from torch.amp.autocast_mode import is_autocast_available
+
+    return device_type if is_autocast_available(device_type) else "cpu"
+
 
 def exists(v):
     return v is not None


### PR DESCRIPTION
This updates PR #670 from the blanket CPU float32 workaround in `main.py`
to the underlying fix described in #662.

On CPU, PyTorch Lightning wraps the forward pass with
`torch.autocast("cpu", dtype=torch.bfloat16)`, so
`torch.autocast("cuda", enabled=False)` is a no-op there. As a result,
the structure and affinity blocks in `boltz2.py` still run under CPU bf16
autocast even though they explicitly cast inputs to float32.

This patch:
- removes the `main.py` CPU precision workaround from this PR
- adds an `autocast_device_type()` helper in `model/modules/utils.py`
- replaces the three hardcoded `torch.autocast("cuda", enabled=False)`
  blocks in `src/boltz/model/models/boltz2.py` with
  `torch.autocast(autocast_device_type(s.device.type), enabled=False)`

Local validation:
- under `torch.autocast("cpu", dtype=torch.bfloat16)`, the old path keeps
  matmul in `torch.bfloat16`
- the new `autocast_device_type(...)` path correctly yields `torch.float32`

Credit:
- @Christopher-Lee-McClendon for the root-cause diagnosis in #662
- @volgin for the helper-based fix pattern used in boltz-community
- @ozvoz for validating the earlier workaround in #653

Closes #653
Closes #662