### PR TITLE
Fix kernel fallback, affinity file path, contact restraints, dead code

### DIFF
--- a/src/boltz/data/write/writer.py
+++ b/src/boltz/data/write/writer.py
@@ -178,7 +178,6 @@ class BoltzWriter(BasePredictionWriter):
                 if self.boltz2 and record.affinity and idx_to_rank[model_idx] == 0:
                     path = struct_dir / f"pre_affinity_{record.id}.npz"
                     np.savez_compressed(path, **asdict(new_structure))
-                    np.array(atoms["coords"][:, None], dtype=Coords)
 
                 # Save confidence summary
                 if "plddt" in prediction:

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -345,6 +345,17 @@ def filter_inputs_structure(
     else:
         existing = set()
 
+    # For records that need affinity prediction, also require pre_affinity_*.npz.
+    # If it's missing (e.g. a prior run without affinity), force re-prediction.
+    affinity_missing = {
+        r.id
+        for r in manifest.records
+        if r.id in existing
+        and r.affinity
+        and not (pred_dir / r.id / f"pre_affinity_{r.id}.npz").exists()
+    }
+    existing -= affinity_missing
+
     # Remove them from the input data
     if existing and not override:
         manifest = Manifest([r for r in manifest.records if r.id not in existing])

--- a/src/boltz/model/layers/triangular_mult.py
+++ b/src/boltz/model/layers/triangular_mult.py
@@ -1,3 +1,5 @@
+import warnings
+
 import torch
 from torch import Tensor, nn
 
@@ -34,6 +36,9 @@ def kernel_triangular_mult(
         g_out_weight=g_out_weight,
         eps=eps,
     )
+
+
+_kernel_failed = False
 
 
 class TriangleMultiplicationOutgoing(nn.Module):
@@ -89,20 +94,30 @@ class TriangleMultiplicationOutgoing(nn.Module):
 
         """
         if use_kernels:
-            return kernel_triangular_mult(
-                x,
-                direction="outgoing",
-                mask=mask,
-                norm_in_weight=self.norm_in.weight,
-                norm_in_bias=self.norm_in.bias,
-                p_in_weight=self.p_in.weight,
-                g_in_weight=self.g_in.weight,
-                norm_out_weight=self.norm_out.weight,
-                norm_out_bias=self.norm_out.bias,
-                p_out_weight=self.p_out.weight,
-                g_out_weight=self.g_out.weight,
-                eps=1e-5,
-            )
+            global _kernel_failed
+            if not _kernel_failed:
+                try:
+                    return kernel_triangular_mult(
+                        x,
+                        direction="outgoing",
+                        mask=mask,
+                        norm_in_weight=self.norm_in.weight,
+                        norm_in_bias=self.norm_in.bias,
+                        p_in_weight=self.p_in.weight,
+                        g_in_weight=self.g_in.weight,
+                        norm_out_weight=self.norm_out.weight,
+                        norm_out_bias=self.norm_out.bias,
+                        p_out_weight=self.p_out.weight,
+                        g_out_weight=self.g_out.weight,
+                        eps=1e-5,
+                    )
+                except (ImportError, RuntimeError) as e:
+                    warnings.warn(
+                        f"Triangle multiplication kernel failed ({e}), "
+                        "falling back to PyTorch implementation.",
+                        stacklevel=2,
+                    )
+                    _kernel_failed = True
 
         # Input gating: D -> D
         x = self.norm_in(x)
@@ -177,20 +192,30 @@ class TriangleMultiplicationIncoming(nn.Module):
 
         """
         if use_kernels:
-            return kernel_triangular_mult(
-                x,
-                direction="incoming",
-                mask=mask,
-                norm_in_weight=self.norm_in.weight,
-                norm_in_bias=self.norm_in.bias,
-                p_in_weight=self.p_in.weight,
-                g_in_weight=self.g_in.weight,
-                norm_out_weight=self.norm_out.weight,
-                norm_out_bias=self.norm_out.bias,
-                p_out_weight=self.p_out.weight,
-                g_out_weight=self.g_out.weight,
-                eps=1e-5,
-            )
+            global _kernel_failed
+            if not _kernel_failed:
+                try:
+                    return kernel_triangular_mult(
+                        x,
+                        direction="incoming",
+                        mask=mask,
+                        norm_in_weight=self.norm_in.weight,
+                        norm_in_bias=self.norm_in.bias,
+                        p_in_weight=self.p_in.weight,
+                        g_in_weight=self.g_in.weight,
+                        norm_out_weight=self.norm_out.weight,
+                        norm_out_bias=self.norm_out.bias,
+                        p_out_weight=self.p_out.weight,
+                        g_out_weight=self.g_out.weight,
+                        eps=1e-5,
+                    )
+                except (ImportError, RuntimeError) as e:
+                    warnings.warn(
+                        f"Triangle multiplication kernel failed ({e}), "
+                        "falling back to PyTorch implementation.",
+                        stacklevel=2,
+                    )
+                    _kernel_failed = True
 
         # Input gating: D -> D
         x = self.norm_in(x)

--- a/src/boltz/model/potentials/potentials.py
+++ b/src/boltz/model/potentials/potentials.py
@@ -73,7 +73,16 @@ class Potential(ABC):
         )
 
         if union_index is not None:
-            neg_exp_energy = torch.exp(-1 * parameters["union_lambda"] * energy)
+            lam_energy = -1 * parameters["union_lambda"] * energy
+            # Numerically stable softmax: subtract per-group max to prevent underflow
+            group_max = torch.full(
+                (*energy.shape[:-1], union_index.max() + 1),
+                float("-inf"),
+                device=energy.device,
+                dtype=energy.dtype,
+            ).scatter_reduce(-1, union_index.expand_as(lam_energy), lam_energy, "amax")
+            shifted = lam_energy - group_max[..., union_index]
+            neg_exp_energy = torch.exp(shifted)
             Z = torch.zeros(
                 (*energy.shape[:-1], union_index.max() + 1), device=union_index.device
             ).scatter_reduce(
@@ -83,7 +92,6 @@ class Potential(ABC):
                 "sum",
             )
             softmax_energy = neg_exp_energy / Z[..., union_index]
-            softmax_energy[Z[..., union_index] == 0] = 0
             return (energy * softmax_energy).sum(dim=-1)
 
         return energy.sum(dim=tuple(range(1, energy.dim())))
@@ -140,7 +148,16 @@ class Potential(ABC):
             *args, negation_mask=negation_mask, compute_derivative=True
         )
         if union_index is not None:
-            neg_exp_energy = torch.exp(-1 * parameters["union_lambda"] * energy)
+            lam_energy = -1 * parameters["union_lambda"] * energy
+            # Numerically stable softmax: subtract per-group max to prevent underflow
+            group_max = torch.full(
+                (*energy.shape[:-1], union_index.max() + 1),
+                float("-inf"),
+                device=energy.device,
+                dtype=energy.dtype,
+            ).scatter_reduce(-1, union_index.expand_as(lam_energy), lam_energy, "amax")
+            shifted = lam_energy - group_max[..., union_index]
+            neg_exp_energy = torch.exp(shifted)
             Z = torch.zeros(
                 (*energy.shape[:-1], union_index.max() + 1), device=union_index.device
             ).scatter_reduce(
@@ -150,7 +167,6 @@ class Potential(ABC):
                 "sum",
             )
             softmax_energy = neg_exp_energy / Z[..., union_index]
-            softmax_energy[Z[..., union_index] == 0] = 0
             f = torch.zeros(
                 (*energy.shape[:-1], union_index.max() + 1), device=union_index.device
             ).scatter_reduce(


### PR DESCRIPTION
Four bugs fixed, each tied to an open upstream issue:

**Triton kernel crash → graceful fallback** (`triangular_mult.py`, fixes #485)
`cuequivariance_torch` throws `RuntimeError("Not Supported")` on incompatible
GPU architectures. Now both triangle multiplication layers catch the error on
first call, warn, and fall back to the pure-PyTorch einsum path for the rest
of the run.

**Affinity `FileNotFoundError` for `pre_affinity_*.npz`** (`main.py`, fixes #390)
`filter_inputs_structure` skipped structure prediction when the output directory
already existed but never checked for `pre_affinity_{id}.npz`. Users who ran
structure prediction first (without affinity) hit a FileNotFoundError on the
affinity step. Now those records are re-predicted so the file is written.

**Contact restraints silently ignored** (`potentials.py`, fixes #621)
The union-softmax used `exp(-λ·energy)`. When all atom pairs violate the
distance constraint (chains 50+ Å apart, λ=8), every exp() underflows to 0 in
float32, making energy and gradient zero — constraints were never enforced.
Fixed with a numerically stable max-shifted softmax (log-sum-exp trick).

**Dead code removed** (`writer.py`)
Orphaned `np.array(...)` line that created an array and discarded it.

## Test plan
- [ ] Multi-chain complex with `force: true` contacts — verify distance bounds respected
- [ ] Affinity input on fresh + existing-structure-only output dirs
- [ ] GPU without cuequivariance support — confirm warning + successful fallback
- [ ] `pytest tests/`