### PR TITLE
[codex] Support prediction resume from embeddings

### DIFF
--- a/src/boltz/data/module/inferencev2.py
+++ b/src/boltz/data/module/inferencev2.py
@@ -298,6 +298,11 @@ class PredictionDataset(torch.utils.data.Dataset):
             print(f"Featurizer failed on {record.id} with error {e}. Skipping.")  # noqa: T201
             return self.__getitem__(0)
 
+        if self.affinity:
+            features["resume_token_idx"] = torch.from_numpy(
+                tokenized.tokens["token_idx"].copy()
+            ).long()
+
         # Add record
         features["record"] = record
         return features

--- a/src/boltz/data/write/writer.py
+++ b/src/boltz/data/write/writer.py
@@ -64,6 +64,35 @@ class BoltzWriter(BasePredictionWriter):
         # Get the records
         records: list[Record] = batch["record"]
 
+        # Embeddings-only mode: no structure was sampled. Dump s/z and exit.
+        if "coords" not in prediction:
+            if (
+                not self.write_embeddings
+                or "s" not in prediction
+                or "z" not in prediction
+            ):
+                return
+            batch_size = len(records)
+            for key in ("s", "z"):
+                if prediction[key].shape[0] != batch_size:
+                    msg = (
+                        f"Prediction field {key} has batch dim "
+                        f"{prediction[key].shape[0]}, expected {batch_size}."
+                    )
+                    raise ValueError(msg)
+            for record_idx, record in enumerate(records):
+                struct_dir = self.output_dir / record.id
+                struct_dir.mkdir(exist_ok=True)
+                if batch_size == 1:
+                    s = prediction["s"].float().cpu().numpy()
+                    z = prediction["z"].float().cpu().numpy()
+                else:
+                    s = prediction["s"][record_idx].float().cpu().numpy()
+                    z = prediction["z"][record_idx].float().cpu().numpy()
+                path = struct_dir / f"embeddings_{record.id}.npz"
+                np.savez_compressed(path, s=s, z=z)
+            return
+
         # Get the predictions
         coords = prediction["coords"]
         coords = coords.unsqueeze(0)
@@ -248,8 +277,8 @@ class BoltzWriter(BasePredictionWriter):
                 
             # Save embeddings
             if self.write_embeddings and "s" in prediction and "z" in prediction:
-                s = prediction["s"].cpu().numpy()
-                z = prediction["z"].cpu().numpy()
+                s = prediction["s"].float().cpu().numpy()
+                z = prediction["z"].float().cpu().numpy()
 
                 path = (
                     struct_dir
@@ -332,6 +361,23 @@ class BoltzAffinityWriter(BasePredictionWriter):
 
         with path.open("w") as f:
             f.write(json.dumps(affinity_summary, indent=4))
+
+        embedding_keys = [
+            key
+            for key in ["affinity_g", "affinity_g1", "affinity_g2"]
+            if key in prediction
+        ]
+        if embedding_keys:
+            emb_path = struct_dir / f"affinity_embeddings_{batch['record'][0].id}.npz"
+            arrays = {
+                key: prediction[key].float().cpu().numpy()
+                for key in embedding_keys
+            }
+            if "resume_token_idx" in batch:
+                arrays["resume_token_idx"] = (
+                    batch["resume_token_idx"][0].detach().cpu().numpy()
+                )
+            np.savez_compressed(emb_path, **arrays)
 
     def on_predict_epoch_end(
         self,

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -320,6 +320,8 @@ def filter_inputs_structure(
     manifest: Manifest,
     outdir: Path,
     override: bool = False,
+    embeddings_only: bool = False,
+    resume_embeddings: bool = False,
 ) -> Manifest:
     """Filter the manifest to only include missing predictions.
 
@@ -331,6 +333,11 @@ def filter_inputs_structure(
         The output directory.
     override: bool
         Whether to override existing predictions.
+    embeddings_only: bool
+        If True, treat an embeddings npz as the completed output.
+    resume_embeddings: bool
+        If True, ignore directories that only contain embeddings when deciding
+        whether a structure prediction already exists.
 
     Returns
     -------
@@ -341,7 +348,25 @@ def filter_inputs_structure(
     # Check if existing predictions are found (only top-level prediction folders)
     pred_dir = outdir / "predictions"
     if pred_dir.exists():
-        existing = {d.name for d in pred_dir.iterdir() if d.is_dir()}
+        if embeddings_only:
+            existing = {
+                d.name
+                for d in pred_dir.iterdir()
+                if d.is_dir() and (d / f"embeddings_{d.name}.npz").exists()
+            }
+        elif resume_embeddings:
+            existing = {
+                d.name
+                for d in pred_dir.iterdir()
+                if d.is_dir()
+                and (
+                    any(d.glob(f"{d.name}_model_*.cif"))
+                    or any(d.glob(f"{d.name}_model_*.pdb"))
+                    or (d / f"pre_affinity_{d.name}.npz").exists()
+                )
+            }
+        else:
+            existing = {d.name for d in pred_dir.iterdir() if d.is_dir()}
     else:
         existing = set()
 
@@ -724,8 +749,14 @@ def process_inputs(
     # Check if records exist at output path
     records_dir = out_dir / "processed" / "records"
     if records_dir.exists():
+        input_ids = {path.stem for path in data}
+
         # Load existing records
-        existing = [Record.load(p) for p in records_dir.glob("*.json")]
+        existing = [
+            record
+            for record in (Record.load(p) for p in records_dir.glob("*.json"))
+            if record.id in input_ids
+        ]
         processed_ids = {record.id for record in existing}
 
         # Filter to missing only
@@ -1039,6 +1070,42 @@ def cli() -> None:
     is_flag=True,
     help=" to dump the s and z embeddings into a npz file. Default is False.",
 )
+@click.option(
+    "--write_affinity_embeddings",
+    is_flag=True,
+    help=(
+        "Dump final affinity-module embeddings for affinity predictions."
+    ),
+)
+@click.option(
+    "--embeddings_only",
+    is_flag=True,
+    help=(
+        "Run only the trunk and dump s/z embeddings; skip diffusion, confidence "
+        "and affinity prediction. Implies --write_embeddings."
+    ),
+)
+@click.option(
+    "--skip_affinity",
+    is_flag=True,
+    help="Skip affinity prediction even when input records request it.",
+)
+@click.option(
+    "--resume_embeddings_dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help=(
+        "Directory containing per-record embeddings_<id>.npz files to resume "
+        "Boltz-2 recycling from. Accepts either a predictions directory with "
+        "<id>/embeddings_<id>.npz or a flat directory with embeddings_<id>.npz."
+    ),
+)
+@click.option(
+    "--resume_recycling_steps",
+    type=int,
+    default=None,
+    help="Recycling step count represented by --resume_embeddings_dir.",
+)
 def predict(  # noqa: C901, PLR0915, PLR0912
     data: str,
     out_dir: str,
@@ -1077,8 +1144,32 @@ def predict(  # noqa: C901, PLR0915, PLR0912
     num_subsampled_msa: int = 1024,
     no_kernels: bool = False,
     write_embeddings: bool = False,
+    write_affinity_embeddings: bool = False,
+    embeddings_only: bool = False,
+    skip_affinity: bool = False,
+    resume_embeddings_dir: Optional[Path] = None,
+    resume_recycling_steps: Optional[int] = None,
 ) -> None:
     """Run predictions with Boltz."""
+    if embeddings_only and model != "boltz2":
+        msg = "--embeddings_only is only supported for Boltz-2."
+        raise click.ClickException(msg)
+
+    if embeddings_only:
+        write_embeddings = True
+
+    if resume_embeddings_dir is not None:
+        if model != "boltz2":
+            msg = "--resume_embeddings_dir is only supported for Boltz-2."
+            raise click.ClickException(msg)
+        if resume_recycling_steps is None:
+            msg = "--resume_recycling_steps is required with --resume_embeddings_dir."
+            raise click.ClickException(msg)
+        if resume_recycling_steps < 0:
+            msg = "--resume_recycling_steps must be non-negative."
+            raise click.ClickException(msg)
+        resume_embeddings_dir = resume_embeddings_dir.expanduser()
+
     # If cpu, write a friendly warning
     if accelerator == "cpu":
         msg = "Running on CPU, this will be slow. Consider using a GPU."
@@ -1184,6 +1275,8 @@ def predict(  # noqa: C901, PLR0915, PLR0912
         manifest=manifest,
         outdir=out_dir,
         override=override,
+        embeddings_only=embeddings_only,
+        resume_embeddings=resume_embeddings_dir is not None,
     )
 
     # Load processed data
@@ -1305,12 +1398,18 @@ def predict(  # noqa: C901, PLR0915, PLR0912
             "write_full_pae": write_full_pae,
             "write_full_pde": write_full_pde,
         }
+        if resume_embeddings_dir is not None:
+            predict_args["resume_embeddings_dir"] = str(resume_embeddings_dir)
+            predict_args["resume_recycling_steps"] = resume_recycling_steps
 
         steering_args = BoltzSteeringParams()
         steering_args.fk_steering = use_potentials
         steering_args.physical_guidance_update = use_potentials
 
         model_cls = Boltz2 if model == "boltz2" else Boltz1
+        extra_kwargs = {}
+        if model == "boltz2":
+            extra_kwargs["embeddings_only"] = embeddings_only
         model_module = model_cls.load_from_checkpoint(
             checkpoint,
             strict=True,
@@ -1322,6 +1421,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
             pairformer_args=asdict(pairformer_args),
             msa_args=asdict(msa_args),
             steering_args=asdict(steering_args),
+            **extra_kwargs,
         )
         model_module.eval()
 
@@ -1333,7 +1433,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
         )
 
     # Check if affinity predictions are needed
-    if any(r.affinity for r in manifest.records):
+    if not embeddings_only and not skip_affinity and any(r.affinity for r in manifest.records):
         # Print header
         click.echo("\nPredicting property: affinity\n")
 
@@ -1377,7 +1477,11 @@ def predict(  # noqa: C901, PLR0915, PLR0912
             "write_confidence_summary": False,
             "write_full_pae": False,
             "write_full_pde": False,
+            "write_affinity_embeddings": write_affinity_embeddings,
         }
+        if resume_embeddings_dir is not None:
+            predict_affinity_args["resume_embeddings_dir"] = str(resume_embeddings_dir)
+            predict_affinity_args["resume_recycling_steps"] = resume_recycling_steps
 
         # Load affinity model
         if affinity_checkpoint is None:

--- a/src/boltz/model/models/boltz2.py
+++ b/src/boltz/model/models/boltz2.py
@@ -1,4 +1,5 @@
 import gc
+from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
@@ -69,6 +70,7 @@ class Boltz2(LightningModule):
         affinity_mw_correction: bool = True,
         run_trunk_and_structure: bool = True,
         skip_run_structure: bool = False,
+        embeddings_only: bool = False,
         token_level_confidence: bool = True,
         alpha_pae: float = 0.0,
         structure_prediction_training: bool = True,
@@ -297,6 +299,7 @@ class Boltz2(LightningModule):
         self.affinity_mw_correction = affinity_mw_correction
         self.run_trunk_and_structure = run_trunk_and_structure
         self.skip_run_structure = skip_run_structure
+        self.embeddings_only = embeddings_only
         self.token_level_confidence = token_level_confidence
         self.alpha_pae = alpha_pae
         self.structure_prediction_training = structure_prediction_training
@@ -407,6 +410,8 @@ class Boltz2(LightningModule):
         diffusion_samples: int = 1,
         max_parallel_samples: Optional[int] = None,
         run_confidence_sequentially: bool = False,
+        resume_embeddings: Optional[list[tuple[Tensor, Tensor]]] = None,
+        resume_recycling_steps: Optional[int] = None,
     ) -> dict[str, Tensor]:
         with torch.set_grad_enabled(
             self.training and self.structure_prediction_training
@@ -431,12 +436,64 @@ class Boltz2(LightningModule):
             # Perform rounds of the pairwise stack
             s = torch.zeros_like(s_init)
             z = torch.zeros_like(z_init)
+            first_recycling_step = 0
+            if resume_embeddings is not None:
+                if resume_recycling_steps is None:
+                    msg = "resume_recycling_steps is required with resume_embeddings."
+                    raise ValueError(msg)
+                if len(resume_embeddings) != s.shape[0]:
+                    msg = (
+                        f"Got {len(resume_embeddings)} resume embedding rows for "
+                        f"batch size {s.shape[0]}."
+                    )
+                    raise ValueError(msg)
+
+                for batch_idx, (resume_s_raw, resume_z_raw) in enumerate(
+                    resume_embeddings
+                ):
+                    resume_s = resume_s_raw.to(device=s.device, dtype=s.dtype)
+                    resume_z = resume_z_raw.to(device=z.device, dtype=z.dtype)
+                    if resume_s.ndim != 2 or resume_z.ndim != 3:
+                        msg = (
+                            "Resume embeddings must have shapes "
+                            "(tokens, token_s) and (tokens, tokens, token_z)."
+                        )
+                        raise ValueError(msg)
+                    if (
+                        resume_s.shape[-1] != s.shape[-1]
+                        or resume_z.shape[-1] != z.shape[-1]
+                    ):
+                        msg = (
+                            "Resume embedding channel dimensions do not match the "
+                            "loaded model."
+                        )
+                        raise ValueError(msg)
+                    if (
+                        resume_s.shape[0] > s.shape[1]
+                        or resume_z.shape[0] > z.shape[1]
+                    ):
+                        msg = (
+                            "Resume embeddings have more tokens than the current batch."
+                        )
+                        raise ValueError(msg)
+                    if resume_z.shape[0] != resume_z.shape[1]:
+                        msg = "Resume z embedding must be square in token dimensions."
+                        raise ValueError(msg)
+                    if resume_z.shape[0] != resume_s.shape[0]:
+                        msg = "Resume s and z token dimensions do not match."
+                        raise ValueError(msg)
+
+                    n_tokens = resume_s.shape[0]
+                    s[batch_idx, :n_tokens] = resume_s
+                    z[batch_idx, :n_tokens, :n_tokens] = resume_z
+
+                first_recycling_step = resume_recycling_steps + 1
 
             # Compute pairwise mask
             mask = feats["token_pad_mask"].float()
             pair_mask = mask[:, :, None] * mask[:, None, :]
             if self.run_trunk_and_structure:
-                for i in range(recycling_steps + 1):
+                for i in range(first_recycling_step, recycling_steps + 1):
                     with torch.set_grad_enabled(
                         self.training
                         and self.structure_prediction_training
@@ -499,6 +556,7 @@ class Boltz2(LightningModule):
                 self.run_trunk_and_structure
                 and ((not self.training) or self.confidence_prediction)
                 and (not self.skip_run_structure)
+                and (not self.embeddings_only)
             ):
                 if self.checkpoint_diffusion_conditioning and self.training:
                     # TODO decide whether this should be with bf16 or not
@@ -582,7 +640,7 @@ class Boltz2(LightningModule):
                 feats["coords"] = feats["coords"].squeeze(1)
                 assert len(feats["coords"].shape) == 3
 
-        if self.confidence_prediction:
+        if self.confidence_prediction and not self.embeddings_only:
             dict_out.update(
                 self.confidence_module(
                     s_inputs=s_inputs.detach(),
@@ -605,7 +663,7 @@ class Boltz2(LightningModule):
                 )
             )
 
-        if self.affinity_prediction:
+        if self.affinity_prediction and not self.embeddings_only:
             pad_token_mask = feats["token_pad_mask"][0]
             rec_mask = feats["mol_type"][0] == 0
             rec_mask = rec_mask * pad_token_mask
@@ -627,6 +685,23 @@ class Boltz2(LightningModule):
 
             with torch.autocast("cuda", enabled=False):
                 if self.affinity_ensemble:
+                    affinity_embeddings = {}
+                    handles = []
+                    if self.predict_args.get("write_affinity_embeddings", False):
+                        handles.append(
+                            self.affinity_module1.affinity_heads.affinity_out_mlp.register_forward_hook(
+                                lambda module, inputs, output: affinity_embeddings.update(
+                                    {"affinity_g1": output.detach()}
+                                )
+                            )
+                        )
+                        handles.append(
+                            self.affinity_module2.affinity_heads.affinity_out_mlp.register_forward_hook(
+                                lambda module, inputs, output: affinity_embeddings.update(
+                                    {"affinity_g2": output.detach()}
+                                )
+                            )
+                        )
                     dict_out_affinity1 = self.affinity_module1(
                         s_inputs=s_inputs.detach(),
                         z=z_affinity.detach(),
@@ -634,8 +709,10 @@ class Boltz2(LightningModule):
                         feats=feats,
                         multiplicity=1,
                         use_kernels=self.use_kernels,
+                        return_embeddings=self.predict_args.get(
+                            "write_affinity_embeddings", False
+                        ),
                     )
-
                     dict_out_affinity1["affinity_probability_binary"] = (
                         torch.nn.functional.sigmoid(
                             dict_out_affinity1["affinity_logits_binary"]
@@ -648,7 +725,37 @@ class Boltz2(LightningModule):
                         feats=feats,
                         multiplicity=1,
                         use_kernels=self.use_kernels,
+                        return_embeddings=self.predict_args.get(
+                            "write_affinity_embeddings", False
+                        ),
                     )
+                    for handle in handles:
+                        handle.remove()
+                    if self.predict_args.get("write_affinity_embeddings", False):
+                        if "affinity_g1" not in affinity_embeddings:
+                            if "affinity_g" in dict_out_affinity1:
+                                affinity_embeddings["affinity_g1"] = (
+                                    dict_out_affinity1["affinity_g"].detach()
+                                )
+                        if "affinity_g2" not in affinity_embeddings:
+                            if "affinity_g" in dict_out_affinity2:
+                                affinity_embeddings["affinity_g2"] = (
+                                    dict_out_affinity2["affinity_g"].detach()
+                                )
+                        if "affinity_g1" not in affinity_embeddings and hasattr(
+                            self.affinity_module1.affinity_heads,
+                            "latest_affinity_g",
+                        ):
+                            affinity_embeddings["affinity_g1"] = (
+                                self.affinity_module1.affinity_heads.latest_affinity_g
+                            )
+                        if "affinity_g2" not in affinity_embeddings and hasattr(
+                            self.affinity_module2.affinity_heads,
+                            "latest_affinity_g",
+                        ):
+                            affinity_embeddings["affinity_g2"] = (
+                                self.affinity_module2.affinity_heads.latest_affinity_g
+                            )
                     dict_out_affinity2["affinity_probability_binary"] = (
                         torch.nn.functional.sigmoid(
                             dict_out_affinity2["affinity_logits_binary"]
@@ -697,9 +804,21 @@ class Boltz2(LightningModule):
                         )
 
                     dict_out.update(dict_out_affinity_ensemble)
+                    if self.predict_args.get("write_affinity_embeddings", False):
+                        dict_out.update(affinity_embeddings)
                     dict_out.update(dict_out_affinity1)
                     dict_out.update(dict_out_affinity2)
                 else:
+                    affinity_embeddings = {}
+                    handles = []
+                    if self.predict_args.get("write_affinity_embeddings", False):
+                        handles.append(
+                            self.affinity_module.affinity_heads.affinity_out_mlp.register_forward_hook(
+                                lambda module, inputs, output: affinity_embeddings.update(
+                                    {"affinity_g": output.detach()}
+                                )
+                            )
+                        )
                     dict_out_affinity = self.affinity_module(
                         s_inputs=s_inputs.detach(),
                         z=z_affinity.detach(),
@@ -707,7 +826,20 @@ class Boltz2(LightningModule):
                         feats=feats,
                         multiplicity=1,
                         use_kernels=self.use_kernels,
+                        return_embeddings=self.predict_args.get(
+                            "write_affinity_embeddings", False
+                        ),
                     )
+                    for handle in handles:
+                        handle.remove()
+                    if self.predict_args.get("write_affinity_embeddings", False):
+                        if "affinity_g" not in affinity_embeddings and hasattr(
+                            self.affinity_module.affinity_heads,
+                            "latest_affinity_g",
+                        ):
+                            affinity_embeddings["affinity_g"] = (
+                                self.affinity_module.affinity_heads.latest_affinity_g
+                            )
                     dict_out.update(
                         {
                             "affinity_pred_value": dict_out_affinity[
@@ -718,6 +850,8 @@ class Boltz2(LightningModule):
                             ),
                         }
                     )
+                    if self.predict_args.get("write_affinity_embeddings", False):
+                        dict_out.update(affinity_embeddings)
 
         return dict_out
 
@@ -1054,8 +1188,93 @@ class Boltz2(LightningModule):
                 # This will aggregate, compute and log all metrics
                 validator.on_epoch_end(model=self)
 
+    @staticmethod
+    def _resume_embedding_path(base_dir: Path, record_id: str) -> Path:
+        nested = base_dir / record_id / f"embeddings_{record_id}.npz"
+        if nested.exists():
+            return nested
+        return base_dir / f"embeddings_{record_id}.npz"
+
+    @staticmethod
+    def _normalize_resume_embedding(array: np.ndarray, name: str) -> Tensor:
+        tensor = torch.as_tensor(array)
+        if name == "s":
+            if tensor.ndim == 3 and tensor.shape[0] == 1:
+                tensor = tensor.squeeze(0)
+            if tensor.ndim != 2:
+                msg = (
+                    "Resume s embedding must have shape "
+                    f"(tokens, token_s), got {tuple(tensor.shape)}."
+                )
+                raise ValueError(msg)
+            return tensor
+        if name == "z":
+            if tensor.ndim == 4 and tensor.shape[0] == 1:
+                tensor = tensor.squeeze(0)
+            if tensor.ndim != 3:
+                msg = (
+                    "Resume z embedding must have shape "
+                    f"(tokens, tokens, token_z), got {tuple(tensor.shape)}."
+                )
+                raise ValueError(msg)
+            return tensor
+        msg = f"Unknown resume embedding name: {name}"
+        raise ValueError(msg)
+
+    @classmethod
+    def _load_resume_embeddings(
+        cls,
+        records: list[Any],
+        base_dir: Path,
+        token_indices: Optional[Tensor] = None,
+        token_masks: Optional[Tensor] = None,
+    ) -> list[tuple[Tensor, Tensor]]:
+        embeddings = []
+        for record_idx, record in enumerate(records):
+            path = cls._resume_embedding_path(base_dir, record.id)
+            if not path.exists():
+                msg = f"Missing resume embeddings for {record.id}: {path}"
+                raise FileNotFoundError(msg)
+            with np.load(path) as data:
+                if "s" not in data or "z" not in data:
+                    msg = (
+                        "Resume embeddings file must contain s and z arrays: "
+                        f"{path}"
+                    )
+                    raise ValueError(msg)
+                s = cls._normalize_resume_embedding(data["s"], "s")
+                z = cls._normalize_resume_embedding(data["z"], "z")
+            if token_indices is not None:
+                indices = token_indices[record_idx].detach().cpu().long()
+                if token_masks is not None:
+                    mask = token_masks[record_idx].detach().cpu().bool()
+                    indices = indices[mask]
+                if indices.numel() == 0:
+                    msg = f"No resume token indices for {record.id}."
+                    raise ValueError(msg)
+                if indices.min().item() < 0 or indices.max().item() >= s.shape[0]:
+                    msg = (
+                        f"Resume token indices for {record.id} are outside the "
+                        f"saved embedding token range 0..{s.shape[0] - 1}."
+                    )
+                    raise ValueError(msg)
+                s = s.index_select(0, indices)
+                z = z.index_select(0, indices).index_select(1, indices)
+            embeddings.append((s, z))
+        return embeddings
+
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> dict:
         try:
+            resume_embeddings = None
+            resume_embeddings_dir = self.predict_args.get("resume_embeddings_dir")
+            if resume_embeddings_dir is not None:
+                resume_embeddings = self._load_resume_embeddings(
+                    batch["record"],
+                    Path(resume_embeddings_dir),
+                    token_indices=batch.get("resume_token_idx"),
+                    token_masks=batch.get("token_pad_mask"),
+                )
+
             out = self(
                 batch,
                 recycling_steps=self.predict_args["recycling_steps"],
@@ -1063,6 +1282,8 @@ class Boltz2(LightningModule):
                 diffusion_samples=self.predict_args["diffusion_samples"],
                 max_parallel_samples=self.predict_args["max_parallel_samples"],
                 run_confidence_sequentially=True,
+                resume_embeddings=resume_embeddings,
+                resume_recycling_steps=self.predict_args.get("resume_recycling_steps"),
             )
             pred_dict = {"exception": False}
             if "keys_dict_batch" in self.predict_args:
@@ -1077,6 +1298,8 @@ class Boltz2(LightningModule):
             if "keys_dict_out" in self.predict_args:
                 for key in self.predict_args["keys_dict_out"]:
                     pred_dict[key] = out[key]
+            if self.embeddings_only:
+                return pred_dict
             pred_dict["coords"] = out["sample_atom_coords"]
             if self.confidence_prediction:
                 # pred_dict["confidence"] = out.get("ablation_confidence", None)
@@ -1118,6 +1341,14 @@ class Boltz2(LightningModule):
                     pred_dict["affinity_probability_binary2"] = out[
                         "affinity_probability_binary2"
                     ]
+                    if self.predict_args.get("write_affinity_embeddings", False):
+                        if "affinity_g1" in out:
+                            pred_dict["affinity_g1"] = out["affinity_g1"]
+                        if "affinity_g2" in out:
+                            pred_dict["affinity_g2"] = out["affinity_g2"]
+                elif self.predict_args.get("write_affinity_embeddings", False):
+                    if "affinity_g" in out:
+                        pred_dict["affinity_g"] = out["affinity_g"]
             return pred_dict
 
         except RuntimeError as e:  # catch out of memory exceptions

--- a/src/boltz/model/modules/affinity.py
+++ b/src/boltz/model/modules/affinity.py
@@ -4,7 +4,6 @@ from torch import nn
 import boltz.model.layers.initialize as init
 from boltz.model.layers.pairformer import PairformerNoSeqModule
 from boltz.model.modules.encodersv2 import PairwiseConditioning
-from boltz.model.modules.transformersv2 import DiffusionTransformer
 from boltz.model.modules.utils import LinearNoBias
 
 
@@ -82,6 +81,7 @@ class AffinityModule(nn.Module):
         feats,
         multiplicity=1,
         use_kernels=False,
+        return_embeddings=False,
     ):
         z = self.z_linear(self.z_norm(z))
         z = z.repeat_interleave(multiplicity, 0)
@@ -133,9 +133,13 @@ class AffinityModule(nn.Module):
 
         # affinity heads
         out_dict.update(
-            self.affinity_heads(z=z, feats=feats, multiplicity=multiplicity)
+            self.affinity_heads(
+                z=z,
+                feats=feats,
+                multiplicity=multiplicity,
+                return_embeddings=return_embeddings,
+            )
         )
-
         return out_dict
 
 
@@ -180,6 +184,7 @@ class AffinityHeadsTransformer(nn.Module):
         z,
         feats,
         multiplicity=1,
+        return_embeddings=False,
     ):
         pad_token_mask = (
             feats["token_pad_mask"].repeat_interleave(multiplicity, 0).unsqueeze(-1)
@@ -210,6 +215,7 @@ class AffinityHeadsTransformer(nn.Module):
         )
 
         g = self.affinity_out_mlp(g)
+        self.latest_affinity_g = g.detach()
 
         affinity_pred_value = self.to_affinity_pred_value(g).reshape(-1, 1)
         affinity_pred_score = self.to_affinity_pred_score(g).reshape(-1, 1)
@@ -220,4 +226,6 @@ class AffinityHeadsTransformer(nn.Module):
             "affinity_pred_value": affinity_pred_value,
             "affinity_logits_binary": affinity_logits_binary,
         }
+        if return_embeddings:
+            out_dict["affinity_g"] = g
         return out_dict


### PR DESCRIPTION
## Summary
- add Boltz-2 prediction options for embeddings-only extraction and resuming from saved trunk embeddings
- crop saved full-token embeddings for affinity prediction using token indices
- optionally write final affinity embeddings alongside affinity summaries

## Validation
- `uv run --extra cuda python -m compileall src/boltz/main.py src/boltz/model/models/boltz2.py src/boltz/data/module/inferencev2.py src/boltz/data/write/writer.py src/boltz/model/modules/affinity.py`
- `uv run --extra cuda ruff check --select E9,F src/boltz/main.py src/boltz/model/models/boltz2.py src/boltz/data/module/inferencev2.py src/boltz/data/write/writer.py src/boltz/model/modules/affinity.py`
- `git diff --check -- src/boltz/main.py src/boltz/model/models/boltz2.py src/boltz/data/module/inferencev2.py src/boltz/data/write/writer.py src/boltz/model/modules/affinity.py`

## Notes
This was validated locally by reusing existing PXR Boltz embeddings for structure and affinity recovery. The full affinity reuse run completed for 4652 inputs with 0 failed examples.