### PR TITLE
feat: MSA column masking option

### DIFF
--- a/src/boltz/data/feature/featurizer.py
+++ b/src/boltz/data/feature/featurizer.py
@@ -897,6 +897,7 @@ def process_msa_features(
     max_seqs: int,
     max_tokens: Optional[int] = None,
     pad_to_max_seqs: bool = False,
+    msa_col_mask_fraction: Optional[float] = 0.0,
 ) -> dict[str, Tensor]:
     """Get the MSA features.
 
@@ -910,6 +911,8 @@ def process_msa_features(
         The maximum number of tokens.
     pad_to_max_seqs : bool
         Whether to pad to the maximum number of sequences.
+    msa_col_mask_fraction : float, optional
+        The fraction of MSA columns to mask.
 
     Returns
     -------
@@ -924,6 +927,22 @@ def process_msa_features(
         deletion.transpose(1, 0),
         paired.transpose(1, 0),
     )  # (N_MSA, N_RES, N_AA)
+
+    # Optional MSA column masking (on token ids, before one-hot), only if more than 1 sequence in MSA
+    if msa_col_mask_fraction > 0.0 and msa.shape[0] > 1:
+        print(f"MSA with {msa_col_mask_fraction} column masking applied.")
+        # sample residue columns to mask across all MSA rows
+        col_mask = torch.rand(msa.shape[1], device=msa.device) < msa_col_mask_fraction
+        mask = torch.zeros_like(msa, dtype=torch.bool)
+
+        # skip masking for first MSA sequence (target sequence)
+        mask[1:, :] = col_mask.unsqueeze(0)
+
+        # avoid re-masking UNK
+        mask = mask & (msa != const.token_ids["UNK"])
+
+        # apply mask to MSA tensor: replace values in msa with UNK where mask is True
+        msa = torch.where(mask, torch.full_like(msa, const.token_ids["UNK"]), msa)
 
     # Prepare features
     msa = torch.nn.functional.one_hot(msa, num_classes=const.num_tokens)
@@ -1143,6 +1162,7 @@ class BoltzFeaturizer:
         inference_binder: Optional[int] = None,
         inference_pocket: Optional[list[tuple[int, int]]] = None,
         compute_constraint_features: bool = False,
+        msa_col_mask_fraction: Optional[float] = 0.0,
     ) -> dict[str, Tensor]:
         """Compute features.
 
@@ -1201,6 +1221,7 @@ class BoltzFeaturizer:
             max_seqs,
             max_tokens,
             pad_to_max_seqs,
+            msa_col_mask_fraction,
         )
 
         # Compute symmetry features

--- a/src/boltz/data/feature/featurizer.py
+++ b/src/boltz/data/feature/featurizer.py
@@ -930,7 +930,6 @@ def process_msa_features(
 
     # Optional MSA column masking (on token ids, before one-hot), only if more than 1 sequence in MSA
     if msa_col_mask_fraction > 0.0 and msa.shape[0] > 1:
-        print(f"MSA with {msa_col_mask_fraction} column masking applied.")
         # sample residue columns to mask across all MSA rows
         col_mask = torch.rand(msa.shape[1], device=msa.device) < msa_col_mask_fraction
         mask = torch.zeros_like(msa, dtype=torch.bool)

--- a/src/boltz/data/feature/featurizerv2.py
+++ b/src/boltz/data/feature/featurizerv2.py
@@ -1577,6 +1577,7 @@ def process_msa_features(
     pad_to_max_seqs: bool = False,
     msa_sampling: bool = False,
     affinity: bool = False,
+    msa_col_mask_fraction: Optional[float] = 0.0,
 ) -> dict[str, Tensor]:
     """Get the MSA features.
 
@@ -1594,6 +1595,8 @@ def process_msa_features(
         Whether to pad to the maximum number of sequences.
     msa_sampling : bool
         Whether to sample the MSA.
+    msa_col_mask_fraction : float
+        The fraction of MSA columns to mask.
 
     Returns
     -------
@@ -1613,6 +1616,22 @@ def process_msa_features(
         deletion.transpose(1, 0),
         paired.transpose(1, 0),
     )  # (N_MSA, N_RES, N_AA)
+
+    # Optional MSA column masking (on token ids, before one-hot), only if more than 1 sequence in MSA
+    if msa_col_mask_fraction > 0.0 and msa.shape[0] > 1:
+        print(f"MSA with {msa_col_mask_fraction} column masking applied.")
+        # sample residue columns to mask across all MSA rows
+        col_mask = torch.rand(msa.shape[1], device=msa.device) < msa_col_mask_fraction
+        mask = torch.zeros_like(msa, dtype=torch.bool)
+
+        # skip masking for first MSA sequence (target sequence)
+        mask[1:, :] = col_mask.unsqueeze(0)
+
+        # avoid re-masking UNK
+        mask = mask & (msa != const.token_ids["UNK"])
+
+        # apply mask to MSA tensor: replace values in msa with UNK where mask is True
+        msa = torch.where(mask, torch.full_like(msa, const.token_ids["UNK"]), msa)
 
     # Prepare features
     assert torch.all(msa >= 0) and torch.all(msa < const.num_tokens)
@@ -2194,6 +2213,7 @@ class Boltz2Featurizer:
         override_coords: Optional[Tensor] = None,
         bfactor_md_correction: bool = False,
         compute_constraint_features: bool = False,
+        msa_col_mask_fraction: Optional[float] = 0.0,
         inference_pocket_constraints: Optional[
             list[tuple[int, list[tuple[int, int]], float]]
         ] = None,
@@ -2286,6 +2306,7 @@ class Boltz2Featurizer:
             max_tokens=max_tokens,
             pad_to_max_seqs=pad_to_max_seqs,
             msa_sampling=training and msa_sampling,
+            msa_col_mask_fraction=msa_col_mask_fraction,
         )
 
         # Compute MSA features

--- a/src/boltz/data/feature/featurizerv2.py
+++ b/src/boltz/data/feature/featurizerv2.py
@@ -1619,7 +1619,6 @@ def process_msa_features(
 
     # Optional MSA column masking (on token ids, before one-hot), only if more than 1 sequence in MSA
     if msa_col_mask_fraction > 0.0 and msa.shape[0] > 1:
-        print(f"MSA with {msa_col_mask_fraction} column masking applied.")
         # sample residue columns to mask across all MSA rows
         col_mask = torch.rand(msa.shape[1], device=msa.device) < msa_col_mask_fraction
         mask = torch.zeros_like(msa, dtype=torch.bool)

--- a/src/boltz/data/module/inference.py
+++ b/src/boltz/data/module/inference.py
@@ -127,6 +127,7 @@ class PredictionDataset(torch.utils.data.Dataset):
         target_dir: Path,
         msa_dir: Path,
         constraints_dir: Optional[Path] = None,
+        msa_col_mask_fraction: float = 0.0,
     ) -> None:
         """Initialize the training dataset.
 
@@ -138,6 +139,8 @@ class PredictionDataset(torch.utils.data.Dataset):
             The path to the target directory.
         msa_dir : Path
             The path to the msa directory.
+        msa_col_mask_fraction : float
+            The fraction of MSA columns to mask.
 
         """
         super().__init__()
@@ -145,6 +148,7 @@ class PredictionDataset(torch.utils.data.Dataset):
         self.target_dir = target_dir
         self.msa_dir = msa_dir
         self.constraints_dir = constraints_dir
+        self.msa_col_mask_fraction = msa_col_mask_fraction
         self.tokenizer = BoltzTokenizer()
         self.featurizer = BoltzFeaturizer()
 
@@ -203,6 +207,7 @@ class PredictionDataset(torch.utils.data.Dataset):
                 inference_binder=binder,
                 inference_pocket=pocket,
                 compute_constraint_features=True,
+                msa_col_mask_fraction=self.msa_col_mask_fraction,
             )
         except Exception as e:  # noqa: BLE001
             print(f"Featurizer failed on {record.id} with error {e}. Skipping.")  # noqa: T201
@@ -233,6 +238,7 @@ class BoltzInferenceDataModule(pl.LightningDataModule):
         msa_dir: Path,
         num_workers: int,
         constraints_dir: Optional[Path] = None,
+        msa_col_mask_fraction: float = 0.0,
     ) -> None:
         """Initialize the DataModule.
 
@@ -248,6 +254,7 @@ class BoltzInferenceDataModule(pl.LightningDataModule):
         self.target_dir = target_dir
         self.msa_dir = msa_dir
         self.constraints_dir = constraints_dir
+        self.msa_col_mask_fraction = msa_col_mask_fraction
 
     def predict_dataloader(self) -> DataLoader:
         """Get the training dataloader.
@@ -263,6 +270,7 @@ class BoltzInferenceDataModule(pl.LightningDataModule):
             target_dir=self.target_dir,
             msa_dir=self.msa_dir,
             constraints_dir=self.constraints_dir,
+            msa_col_mask_fraction=self.msa_col_mask_fraction,
         )
         return DataLoader(
             dataset,

--- a/src/boltz/data/module/inferencev2.py
+++ b/src/boltz/data/module/inferencev2.py
@@ -165,6 +165,7 @@ class PredictionDataset(torch.utils.data.Dataset):
         mol_dir: Path,
         constraints_dir: Optional[Path] = None,
         template_dir: Optional[Path] = None,
+        msa_col_mask_fraction: float = 0.0,
         extra_mols_dir: Optional[Path] = None,
         override_method: Optional[str] = None,
         affinity: bool = False,
@@ -184,7 +185,9 @@ class PredictionDataset(torch.utils.data.Dataset):
         constraints_dir : Optional[Path]
             The path to the constraints directory.
         template_dir : Optional[Path]
-            The path to the template directory.
+            The path to the template directory.   
+        msa_col_mask_fraction : float
+            The fraction of MSA columns to mask.
 
         """
         super().__init__()
@@ -194,6 +197,7 @@ class PredictionDataset(torch.utils.data.Dataset):
         self.mol_dir = mol_dir
         self.constraints_dir = constraints_dir
         self.template_dir = template_dir
+        self.msa_col_mask_fraction = msa_col_mask_fraction
         self.tokenizer = Boltz2Tokenizer()
         self.featurizer = Boltz2Featurizer()
         self.canonicals = load_canonicals(self.mol_dir)
@@ -288,6 +292,7 @@ class PredictionDataset(torch.utils.data.Dataset):
                 inference_pocket_constraints=pocket_constraints,
                 inference_contact_constraints=contact_constraints,
                 compute_constraint_features=True,
+                msa_col_mask_fraction=self.msa_col_mask_fraction,
                 override_method=self.override_method,
                 compute_affinity=self.affinity,
             )
@@ -324,6 +329,7 @@ class Boltz2InferenceDataModule(pl.LightningDataModule):
         msa_dir: Path,
         mol_dir: Path,
         num_workers: int,
+        msa_col_mask_fraction: float = 0.0,
         constraints_dir: Optional[Path] = None,
         template_dir: Optional[Path] = None,
         extra_mols_dir: Optional[Path] = None,
@@ -344,6 +350,8 @@ class Boltz2InferenceDataModule(pl.LightningDataModule):
             The path to the moldir.
         num_workers : int
             The number of workers to use.
+        msa_col_mask_fraction : float
+            The fraction of MSA columns to mask.
         constraints_dir : Optional[Path]
             The path to the constraints directory.
         template_dir : Optional[Path]
@@ -360,6 +368,7 @@ class Boltz2InferenceDataModule(pl.LightningDataModule):
         self.target_dir = target_dir
         self.msa_dir = msa_dir
         self.mol_dir = mol_dir
+        self.msa_col_mask_fraction = msa_col_mask_fraction
         self.constraints_dir = constraints_dir
         self.template_dir = template_dir
         self.extra_mols_dir = extra_mols_dir
@@ -382,6 +391,7 @@ class Boltz2InferenceDataModule(pl.LightningDataModule):
             mol_dir=self.mol_dir,
             constraints_dir=self.constraints_dir,
             template_dir=self.template_dir,
+            msa_col_mask_fraction=self.msa_col_mask_fraction,
             extra_mols_dir=self.extra_mols_dir,
             override_method=self.override_method,
             affinity=self.affinity,

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -1030,6 +1030,12 @@ def cli() -> None:
     default=1024,
 )
 @click.option(
+    "--msa_col_mask_fraction",
+    type=click.FloatRange(0.0, 1.0),
+    default=0.0,
+    help="The masking rate for MSA columns (replace with X). Default is 0.0 (no masking).",
+)
+@click.option(
     "--no_kernels",
     is_flag=True,
     help="Whether to disable the kernels. Default False",
@@ -1075,6 +1081,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
     max_msa_seqs: int = 8192,
     subsample_msa: bool = True,
     num_subsampled_msa: int = 1024,
+    msa_col_mask_fraction: float = 0.0,
     no_kernels: bool = False,
     write_embeddings: bool = False,
 ) -> None:
@@ -1279,6 +1286,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
                 template_dir=processed.template_dir,
                 extra_mols_dir=processed.extra_mols_dir,
                 override_method=method,
+                msa_col_mask_fraction=msa_col_mask_fraction,
             )
         else:
             data_module = BoltzInferenceDataModule(
@@ -1287,6 +1295,7 @@ def predict(  # noqa: C901, PLR0915, PLR0912
                 msa_dir=processed.msa_dir,
                 num_workers=num_workers,
                 constraints_dir=processed.constraints_dir,
+                msa_col_mask_fraction=msa_col_mask_fraction,
             )
 
         # Load model


### PR DESCRIPTION
Added an AFSample3 style column masking option during MSA featurization.

Allows user to replace (randomly) a specified percentage of the input MSA columns with unknown residues ("X/UNK") to improve conformational diversity.

Tested with both boltz1/2.

Reference for AFSample3: https://www.biorxiv.org/content/10.64898/2026.01.16.699904v1