### PR TITLE
docs: clarify affinity output conversion

### DIFF
--- a/docs/prediction.md
+++ b/docs/prediction.md
@@ -246,7 +246,9 @@ The `affinity_pred_value` aims to measure the specific affinity of different bin
 - IC50 of $10^{-6}$ M $\longrightarrow$ our model outputs $0$ (moderate binder)
 - IC50 of $10^{-4}$ M $\longrightarrow$ our model outputs $2$ (weak binder / decoy)
 
-You can convert the model's output to pIC50 in `kcal/mol` by using `y --> (6 - y) * 1.364` where `y` is the model's prediction.
+You can convert the model's output to pIC50 using $\mathrm{pIC}_{50} = 6 - y$, where $y = \log_{10}(\mathrm{IC}_{50} / \mu\mathrm{M})$. pIC50 is dimensionless.
+
+If IC50 is approximated as an equilibrium dissociation constant, the corresponding standard binding free energy at 298 K and a 1 M standard state is approximately $\Delta G^\circ \approx -(1.364\ \mathrm{kcal\,mol}^{-1})\mathrm{pIC}_{50}$. This approximation should be interpreted cautiously because IC50 is assay-dependent and is not generally equal to $K_d$ or $K_i$.
 
 
 ## Authentication to MSA Server


### PR DESCRIPTION
## TL;DR

Documentation-only fix to the `affinity_pred_value` documentation. It separates the dimensionless pIC50 conversion from the optional $\Delta G^\circ$ approximation, corrects the free-energy sign, and states the assumptions. No behavior change.

## Before → after

| | Before | After |
| --- | --- | --- |
| pIC50 units | Labeled `kcal/mol` | Dimensionless |
| Conversion | pIC50 and $\Delta G^\circ$ merged into one expression | Two separate expressions |
| $\Delta G^\circ$ sign | Positive | Negative |
| Assumptions | Not stated | 298 K, 1 M standard state, and assay-dependent IC50 is not generally $K_d$ or $K_i$ |

## Formula change

**Before:** `(6 - y) * 1.364`, described as “pIC50 in kcal/mol”

**After:**

- $\mathrm{pIC}_{50} = 6 - y$ (dimensionless)
- $\Delta G^\circ \approx -(1.364\ \mathrm{kcal\,mol}^{-1})\mathrm{pIC}_{50}$ (optional approximation)

## Why it matters

The old wording could lead readers to treat an assay-dependent potency as a thermodynamic binding free energy with the wrong sign; the revised text distinguishes the quantities and makes the approximation explicit.

## Validation

Reviewed the Markdown source and raw PR diff · `git diff --check` clean
